### PR TITLE
10_snappy.cfg: use correct value type to silence a deprecation from cloud…

### DIFF
--- a/static/etc/cloud/cloud.cfg.d/10_snappy.cfg
+++ b/static/etc/cloud/cloud.cfg.d/10_snappy.cfg
@@ -3,7 +3,7 @@
 # growpart module fails as 'sgdisk' is not present
 # but even if it were, we would not want to run it
 growpart:
-   mode: off
+   mode: 'off'
 
 # resize_rootfs (using resize2fs) fails, we wouldnt want resize
 # of the root partition anyway (data partition would be more useful).


### PR DESCRIPTION
After speaking to the server team it seems we produce an DEPRECATED message due to the schema validation. Silence this to avoid this message.

This partially (another thing is also causing this, see https://github.com/canonical/cloud-init/issues/5192) causes `cloud-init status` to return an error code '2', even though it produces the output `status: done`.

This causes snapd to treat it like an error, even though there was no error.

The fix we actually need is to make sure snapd checks for `status: done` instead of relying on the error code