### PR TITLE
writable-paths: add /var/lib/dhcpcd writable-paths for datasource discovery

### DIFF
--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -54,6 +54,7 @@
 /var/lib/apparmor                       auto                    persistent  transition  none
 /var/lib/dbus                           auto                    persistent  none        none
 /var/lib/dhcp                           auto                    persistent  none        none
+/var/lib/dhcpcd                         auto                    persistent  transition  none
 # cloud-init
 /etc/cloud                              auto                    persistent  transition  none
 /var/lib/cloud                          auto                    persistent  none        none


### PR DESCRIPTION
If dhcpcd is installed in a cloud image, cloud-init may attempt early datasource discovery using dhcpcd in order to get information about active instance metadata service IP addresses and routes. The dhcpcd client writes out leases which cloud-init parses under /var/lib/dhcpcd.

Add this support so cloud-init can detect network-bound datasources such as Azure, Ec2 and GCE.