### PR TITLE
feat(azure): support cloud-init persistent writes to /var/lib/waagent

### DIFF
--- a/hooks/020-extra-files.chroot
+++ b/hooks/020-extra-files.chroot
@@ -35,6 +35,7 @@ chmod 700 /var/lib/private
 echo "extra cloud init files"
 mkdir -p /etc/cloud
 mkdir -p /var/lib/cloud
+mkdir -p /var/lib/waagent
 
 echo "console-conf directories"
 mkdir -p /var/lib/console-conf

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -57,6 +57,7 @@
 # cloud-init
 /etc/cloud                              auto                    persistent  transition  none
 /var/lib/cloud                          auto                    persistent  none        none
+/var/lib/waagent                        auto                    persistent  none  none
 # for various clouds like GCE
 /etc/sysctl.d                           auto                    persistent  transition  none
 # swapfile


### PR DESCRIPTION
This branch represents a more cloud-specific need if cloud-init were looking to support cloud-images on Azure as cloud-init's Azure datasource needs to write out state to /var/lib/waagent directory. As such, I wonder if there are ways to fragment or specialize the writable-paths we want to consider when we generate a core image for a targeted/specific platform.