### PR TITLE
feat(azure): support cloud-init persistent writes to /var/lib/waagent

### DIFF
--- a/hooks/020-extra-files.chroot
+++ b/hooks/020-extra-files.chroot
@@ -35,6 +35,7 @@ chmod 700 /var/lib/private
 echo "extra cloud init files"
 mkdir -p /etc/cloud
 mkdir -p /var/lib/cloud
+mkdir -p /var/lib/waagent
 
 echo "console-conf directories"
 mkdir -p /var/lib/console-conf

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -57,6 +57,7 @@
 # cloud-init
 /etc/cloud                              auto                    persistent  transition  none
 /var/lib/cloud                          auto                    persistent  none        none
+/var/lib/waagent                        auto                    persistent  none  none
 # for various clouds like GCE
 /etc/sysctl.d                           auto                    persistent  transition  none
 # swapfile


### PR DESCRIPTION
cloud-init persists any configuration data crawled from Azure instance metadata service  or ovf-env.xml files to /var/lib/waagent directory to allow walinux-agent to interact with various early boot configuration seeds. If that directory does not exist or is readonly cloud-init will hit a permissions error resulting in inability to detect the Azure instance metadata service to obtain boot-time cloud-init configuration.