### PR TITLE
static: wait for kernel driver for services that load modules

### DIFF
--- a/static/usr/lib/systemd/system/modprobe@.service.d/wait-modules.conf
+++ b/static/usr/lib/systemd/system/modprobe@.service.d/wait-modules.conf
@@ -1,0 +1,3 @@
+# TODO remove once we start to mount from initramfs
+[Unit]
+After=usr-lib-modules.mount usr-lib-firmware.mount

--- a/static/usr/lib/systemd/system/proc-sys-fs-binfmt_misc.mount.d/wait-modules.conf
+++ b/static/usr/lib/systemd/system/proc-sys-fs-binfmt_misc.mount.d/wait-modules.conf
@@ -1,0 +1,3 @@
+# TODO remove once we start to mount from initramfs
+[Unit]
+After=usr-lib-modules.mount usr-lib-firmware.mount


### PR DESCRIPTION
Wait for kernel modules to be mounted in modprobe@.service and mount for /proc/sys/fs/binfmt_misc/, as these load modules. This is in principle a workaround until we start to mount modules and firmware from the initramfs.