### PR TITLE
static: mount some directories from initramfs

### DIFF
--- a/.github/workflows/lxd-image.yaml
+++ b/.github/workflows/lxd-image.yaml
@@ -10,7 +10,7 @@ jobs:
         run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install spread
         run: curl -s https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | sudo tar xzv -C /usr/bin
       - name: Run tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: x86 build
         run: |
@@ -33,7 +33,7 @@ jobs:
           spread-arm -artifacts=./artifacts google-nested-arm:tests/spread/build/
           find ./artifacts -type f -name "*.artifact" -exec cp {} "${{ github.workspace }}" \;
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: core-snap
           path: "${{ github.workspace }}/core24.artifact"
@@ -55,8 +55,8 @@ jobs:
         run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: core-snap
           path: "${{ github.workspace }}/core24.artifact"
@@ -86,14 +86,14 @@ jobs:
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
       
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: core-base
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: 'snapcore/snapd'
           path: snapd
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: core-snap
       

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -8,13 +8,13 @@
 # See writable-paths(5) for full details.
 # --------------------------------------------------------------------
 /home                                   user-data               persistent  transition  none
-/snap                                   auto                    persistent  none        none
+/snap                                   auto                    persistent  none        x-initrd.mount
 # snappy security policy, etc
-/var/lib/snapd                         auto                     persistent  transition  none
+/var/lib/snapd                         auto                     persistent  transition  x-initrd.mount
 # snap catalogue (sections, pkgnames)
 /var/cache/snapd                        auto                    persistent  transition  none
 # snap data
-/var/snap                               auto                    persistent  transition  none
+/var/snap                               auto                    persistent  transition  x-initrd.mount
 # generic
 /media                                  none                    temporary   none        defaults
 /mnt                                    none                    temporary   none        defaults

--- a/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
+++ b/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Run shellCheck for tools
       run: |
@@ -23,7 +23,7 @@ jobs:
     runs-on: self-hosted
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Run test
       run: |


### PR DESCRIPTION
We want to mount /snap and /var/lib/snapd from the initramfs as they are a requisite to mount the kernel snap from initramfs.