### PR TITLE
static: mount some directories from initramfs

### DIFF
--- a/.github/workflows/lxd-image.yaml
+++ b/.github/workflows/lxd-image.yaml
@@ -10,7 +10,7 @@ jobs:
         run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install spread
         run: curl -s https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | sudo tar xzv -C /usr/bin
       - name: Run tests

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -8,13 +8,13 @@
 # See writable-paths(5) for full details.
 # --------------------------------------------------------------------
 /home                                   user-data               persistent  transition  none
-/snap                                   auto                    persistent  none        none
+/snap                                   auto                    persistent  none        x-initrd.mount
 # snappy security policy, etc
-/var/lib/snapd                         auto                     persistent  transition  none
+/var/lib/snapd                         auto                     persistent  transition  x-initrd.mount
 # snap catalogue (sections, pkgnames)
 /var/cache/snapd                        auto                    persistent  transition  none
 # snap data
-/var/snap                               auto                    persistent  transition  none
+/var/snap                               auto                    persistent  transition  x-initrd.mount
 # generic
 /media                                  none                    temporary   none        defaults
 /mnt                                    none                    temporary   none        defaults

--- a/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
+++ b/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Run shellCheck for tools
       run: |
@@ -23,7 +23,7 @@ jobs:
     runs-on: self-hosted
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Run test
       run: |


### PR DESCRIPTION
We want to mount some folders from the initramfs as they
are a requisite to mount the kernel snap from initramfs:
- /snap is the root of the mountpoints for the kernel snap and
  kernel-modules components
- /var/lib/snapd contains the drivers tree and the snap and component
  files
- /var/snap might contain dynamically generated kernel modules, and we
  want the links from the drivers tree to be valid since the moment we
  switch root.

Backport from https://github.com/canonical/core-base/pull/245
