### PR TITLE
core22: add FIPS build support

### DIFF
--- a/fips.conf.example
+++ b/fips.conf.example
@@ -1,0 +1,4 @@
+# replace the <LOGIN> and <PASSWORD> with your own private access
+# information from launchpad
+# OBS: these comments should be removed
+machine private-ppa.launchpadcontent.net/ubuntu-advantage/pro-fips-updates login <LOGIN> password <PASSWORD>

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -90,10 +90,77 @@ ebrtrD1Hrw3BetRY4aQ0ysRSugvbTwqS0d17zepomYJS49Jy2w2D
 
 EOF
 
+# write FIPS PPA files if the current build is a FIPS build
+if [[ ${SNAP_FIPS_BUILD+x} ]]; then
+    # for private builds a conf file is neccessary, setup for PPA access
+    # if provided
+    if [ -e etc/apt/auth.conf.d/01-fips.conf ]; then
+        # add fips personal token
+        echo "deb https://private-ppa.launchpadcontent.net/ubuntu-advantage/pro-fips-updates/ubuntu $CODENAME main" > /etc/apt/sources.list.d/fips.list
+        cat >etc/apt/trusted.gpg.d/fips-cc-stig.asc <<'EOF'
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Comment: Hostname: 
+Version: Hockeypuck 2.2
+
+xsFNBFh0EVMBEADtYpUnr+dqc8RfZr8+JYkACfr/X6Tdh0X3D4Bjlpukcvb4oEgY
+R9q/u7zz3sqfpmB3/BrU/D/IYyHPRZRznQNszb9/8XCI4wWseJE5M2ZrjJWd7Ibx
+OcQFnq9zZ+ZI19YKAtq4vh3EdjTAOFQAwvUgd+s3DKymHtXhCk00Pp92xg3sY/4L
+8jalDWjzpEN3ZKdx/A15I6+114FJs6+YphbCvmOuoKqeIhsadyEXkQxWxZSIVL4T
+xWAiZZsdbVm4HlWRG/fwtj+CbOrUZIxVCndW7RibBdT9I2yjHSSJhxTXdSbo5gqH
+zG5iwpAOSNQcBHfTbsXPAvT1A0Jgn9CE2y4kdLbGQ6DR7ACppoHYW+EcqV9bsZ/+
+WRgVXv4PBPYdlC0WNBWWRHC9pJjhef0uI5asgCtNU+2VqLCAd8Yg6B4xCE2r6aJW
+c48cB2U7vml2i8swRYRMoB+R/QXXCKX3ZUoBU8LxIz4+qZxL4w27fuVJ8T8Sduzm
+XK9403MTr+Odg8yczdUzbX93Hl8lvLhIaTUeRq0C5NzhRHkXeiQzBeiDY+JujiGd
+YS7B5aKhOGeOm34j1PcYrHPfPGE69VtfNpqmktKCgWdf62d+G11GhBWhB/BI+r4n
+8/Rs8D48EGRjpPG6zVpi6NLdVOXQfBh2WxGRBBwCn46u3gF51u5AcuJg7wARAQAB
+zSJMYXVuY2hwYWQgUFBBIGZvciB1YnVudHUtYWR2YW50YWdlwsF4BBMBAgAiBQJY
+dBFTAhsDBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRD2woAXjRMCjKvDD/9h
+odnZ0G7hlUbDwuJvBMnmOdkop+MwHOkncA+464PLv/uM8R4L952te+ig+niKudb+
+n0ja2k75w7wKVARALkrpMNBs4eLBqE2oh+O6lfJGNZEx829ReM9owo1jLthRx6E4
+epCbtWXS3jqLSzG+4gK7+TnJIFTDKr7bkwmNQCO7yqs9nTal7CBL5CrMHf9xEjbn
+hcpVZ+Lq1Se+fZvvXZLMLMldC8a9xCDljVoscQq0LfcH12qln+sNQCDnH6aKyJXS
+8rshM1b5vkicWOY5Bqj7M9O+IUSywzL/+qWkvCxEKwyOEoGlADscpvIAQui4838l
+i7Cij97roSqxogO5qHAbWQAwO/45vFnQil0oxIW0zldO2qDHgKOVuu1L1NGKfgBq
+QzltHvW/JHDBtIbbOFC3uvdfEwnN0IETEOZEUz8/UCF1Y0Got/c4AOMgzhVuukbX
+1DUts8EE6fvRooaf6pB00T7uL5HT0UD7me8hd6L91EXsyiaoxKaXZKY+PcqcHsEL
+tkf3Lo2mGHd3qVxnEmTd08bMsYc8QDnSYsTL0bplHhKc6I/cx26B2KCOG73+LqI7
+jhT5aNkxK0VP5x7LwaSS7Q0wGwZOFnTjNVFa2LH0BQXO2V5jdnbFEctDyR6RoLeF
+72VRL2qqfB51M5ymyLuihZZTbDRGnkeNxUteX1HBXMLBcwQQAQoAHRYhBEqQl0us
+4KmmrwmzsWw5wcFqnae+BQJbgM+6AAoJEGw5wcFqnae+zz0P/2mNZqkwzm+TgOG5
+JT1dF20++4rtIw6Ib96Y/0Q6tDWWYs29c/8891ka5bI4SNLwWxH0KA0b+uQwQwHh
+ZUwzQJyOV7ENvx5FfvxFKbv6z+MdmQmBzRR323Zc36SlTCUPl/gklZxXhMd+fsQ8
+Uww04NszGue7Bb429uGvsWOefeb0o4wKYp7wPqOJF315J4twlx0ui7dTIcQN6Aoi
+1g2VgQrqzYVdjUNaBzJ/RmN/Y/LWfYcn48XXpTVl1Pe3jU2A6nOaAIwVonj/ACd1
+4lGMwtMbLe+ePO4jKkyVj0OBzTP79nkJN1PA/Gge5i92dr4Bs5jiUjqlCE8GL36H
+5jDJ7Tb8LsZModHFsGMS7H91czA7pjaJCBWWI5U042bPr8Es8e9FwVCYKpUadvj3
+Lm9uLPhYYaG+ezFqO3xXnRDfhobEkAJcJEc5O/UecxgB0cXHMJXwkfh4rTN5MT/8
+ZYGggMvzEfsWXjtQIV/+xV87N/LSJZSTQyJkpT/sPqsjZeX9wOAqMtq3gIZCq4My
+HrXIyFVpmZJ0UDn907rIraJS+4mD0xNaaoXWd99YvhFycLj3YPl4B8KQ/1b/amQ0
+Dyi6+RIJ+lHVuuiZH3fqNER795RdpLHKLpgj4kO6ywfeliM3qLeJMWulTHvt6bUY
+5PWi/YMXleL8jD8NwK6eBIkbcBkd
+=1S42
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+    fi
+
+    mkdir -p etc/apt/preferences.d/
+    cat >etc/apt/preferences.d/fips.pref <<'EOF'
+Package: *
+Pin: release o=LP-PPA-ubuntu-advantage-pro-fips-updates
+Pin-Priority: 1010
+EOF
+fi
 
 # install some packages we need
 apt update
-apt dist-upgrade -y
+
+# when doing a FIPS build we will allow downgrades due to package
+# versions possibly being lower in the FIPS ppa
+if [[ ${SNAP_FIPS_BUILD+x} ]]; then
+    apt-get dist-upgrade -y --allow-downgrades
+else
+    apt-get dist-upgrade -y
+fi
 
 PACKAGES=(
     apparmor
@@ -163,6 +230,14 @@ case "$(dpkg --print-architecture)" in
         ;;
 esac
 
-apt install --no-install-recommends -y "${PACKAGES[@]}"
+if [[ ${SNAP_FIPS_BUILD+x} ]]; then
+    # Ensure vital crypt packages are refreshed / downgraded and downloaded
+    # from the FIPS ppa. This should also contain openssh-server, but we already
+    # have that one listed above.
+    PACKAGES+=(libgcrypt20 libgnutls30 openssl-fips-module-3)
+    apt-get install --no-install-recommends --allow-downgrades -y "${PACKAGES[@]}"
+else
+    apt-get install --no-install-recommends -y "${PACKAGES[@]}"
+fi
 
 apt autoremove -y

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -97,8 +97,16 @@ parts:
       - python3-requests
       - python3-yaml
     override-pull: |
-      craftctl set version="$(/bin/date +%Y%m%d)"
       craftctl default
+      # detect whether we are doing a fips build on LP
+      if git remote get-url origin | grep "fips"; then
+        craftctl set version="$(/bin/date +%Y%m%d)+fips"
+        echo "SNAP_FIPS_BUILD=1" > ./.fips-env
+        echo "SNAP_CORE_TRACK=fips-updates" >> ./.fips-env
+      else
+        craftctl set version="$(/bin/date +%Y%m%d)"
+        rm -f ./.fips-env
+      fi
     override-prime: |
       craftctl default
       # ensure build-in tests are run

--- a/tools/generate-changelog.py
+++ b/tools/generate-changelog.py
@@ -41,8 +41,10 @@ from collections import namedtuple
 pkg_allowed_list = [
     'apt', # is removed during hook
     'libapt-pkg6.0', # is removed as well
-    'base-files', # changelog missing in rootfs
-    'ca-certificates' # changelog missing in rootfs
+    'base-files', # unstable on local builds
+    'ca-certificates', # unstable on local builds
+    'gnutls-bin', # fails for FIPS builds
+    'distro-info-data' # unstable on local builds
 ]
 
 # Returns a dictionary from package name to version, using
@@ -59,9 +61,11 @@ def packages_from_manifest(manifest_p):
             pkg_dict[pkg_data[0]] = pkg_data[1]
         return pkg_dict
 
+
 def package_name(pkg):
     t = pkg.split(':')
     return t[0]
+
 
 def get_changelog_from_file(docs_d, pkg):
     chl_deb_path = docs_d + '/' + package_name(pkg) + '/changelog.Debian.gz'
@@ -73,7 +77,8 @@ def get_changelog_from_file(docs_d, pkg):
         with gzip.open(chl_deb_path) as chl_fh:
             return chl_fh.read().decode('utf-8')
     else:
-        raise FileNotFoundError("no supported changelog found for package " + pkg)
+        raise FileNotFoundError(f"no supported changelog found for package {pkg}")
+
 
 def get_changelog_from_url(pkg, new_v, on_lp):
     url = 'https://changelogs.ubuntu.com/changelogs/binary/'


### PR DESCRIPTION
This is a backport of the core24 FIPS PR https://github.com/canonical/core-base/pull/249 .

The major difference here is that we pull the correct core-base to do changelog against for FIPS, and that we use a different PPA.