### PR TITLE
hooks: include nvidia rules only for supported arches

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -261,10 +261,15 @@ dpkg --fsys-tarfile snapd_*.deb |
        tar xf - ./usr/lib/systemd/system-generators/snapd-generator
 rm snapd_*.deb
 
-# Copy nvidia udev rules and dependencies (sources for this come from
-# Canonical, not from Nvidia, see
-# https://github.com/canonical/nvidia-graphics-drivers).
-nvidia_common_pkg=nvidia-kernel-common-550
-apt-get download "$nvidia_common_pkg"
-dpkg --fsys-tarfile "$nvidia_common_pkg"_*.deb |
-       tar xf - ./sbin/ub-device-create ./lib/udev/rules.d/71-nvidia.rules
+
+case "$(dpkg --print-architecture)" in
+    amd64|arm64)
+        # Copy nvidia udev rules and dependencies (sources for this come from
+        # Canonical, not from Nvidia, see
+        # https://github.com/canonical/nvidia-graphics-drivers).
+        nvidia_common_pkg=nvidia-kernel-common-550
+        apt-get download "$nvidia_common_pkg"
+        dpkg --fsys-tarfile "$nvidia_common_pkg"_*.deb |
+            tar xf - ./sbin/ub-device-create ./lib/udev/rules.d/71-nvidia.rules
+        ;;
+esac


### PR DESCRIPTION
Backport of https://github.com/canonical/core-base/pull/268