### PR TITLE
hooks: move pam.d files into /usr/lib/pam.d

### DIFF
--- a/hook-tests/031-faillock.test
+++ b/hook-tests/031-faillock.test
@@ -2,4 +2,4 @@
 
 set -eu
 
-grep pam_faillock.so etc/pam.d/common-auth
+grep pam_faillock.so usr/lib/pam.d/common-auth

--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -17,7 +17,20 @@ rm -rvf /etc/selinux
 rm -rvf /etc/binfmt.d
 rm /etc/gai.conf
 rm /etc/debian_version
+
+# pam stuff, move pam.d files into /usr/lib/pam.d instead of
+# /etc/pam.d to allow snaps to mount their own pam.d files as well
 rm /etc/pam.conf
+
+# move pam.d files from /etc/pam.d to /usr/lib/pam.d to allow snaps
+# to mount on top and provide their own.
+mv etc/pam.d/* usr/lib/pam.d
+
+# Prefix all includes with /usr/lib/pam.d for now, we have to do this unfortunately
+# due to a bug in the debian patch for @includes.
+# See filed bug: https://bugs.launchpad.net/ubuntu/+source/pam/+bug/2087827
+# XXX: Remove this line once its fixed upstream
+find usr/lib/pam.d/ -type f -exec sed -i -e 's/\@include /\@include \/usr\/lib\/pam.d\//g' {} \;
 
 # cloud-init adds stuff here
 rm -rvf /etc/profile.d/Z99-cloud*

--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -18,8 +18,6 @@ rm -rvf /etc/binfmt.d
 rm /etc/gai.conf
 rm /etc/debian_version
 
-# pam stuff, move pam.d files into /usr/lib/pam.d instead of
-# /etc/pam.d to allow snaps to mount their own pam.d files as well
 rm /etc/pam.conf
 
 # move pam.d files from /etc/pam.d to /usr/lib/pam.d to allow snaps


### PR DESCRIPTION
Leave /etc/pam.d empty for Core Desktop to experiment with their own per-snap profiles.

A little info surrounding profile loading, also see the [man-pages](https://manpages.opensuse.org/Tumbleweed/pam-manpages/pam.d.5.en.html)

There are three directories, in which PAM is looking for the service files in the following order:

* /etc/pam.d
* /usr/lib/pam.d

If a file is not found in /etc/pam.d, it will be searched in /usr/lib/pam.d and afterwards in /usr/etc/pam.d. 

Considering this function in the source: https://github.com/linux-pam/linux-pam/blob/37b416c152ed833dcc55c84068c77eb713748d24/libpam/pam_handlers.c#L293 
it looks like this should be no issues

**UPDATE** It turned out that include files from pam.d files do only check in `/etc/pam.d`, which on the surface looks like to be a misalignment with the man-pages. Filed bug https://bugs.launchpad.net/ubuntu/+source/pam/+bug/2087827

REF: SNAPDENG-34125