### PR TITLE
hooks: include nvidia modprobe configuration from deb

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -264,13 +264,16 @@ rm snapd_*.deb
 
 case "$(dpkg --print-architecture)" in
     amd64|arm64)
-        # Copy nvidia udev rules and dependencies (sources for this come from
+        # Copy nvidia config files and dependencies (sources for this come from
         # Canonical, not from Nvidia, see
         # https://github.com/canonical/nvidia-graphics-drivers).
         nvidia_common_pkg=nvidia-kernel-common-550
         apt-get download "$nvidia_common_pkg"
         dpkg --fsys-tarfile "$nvidia_common_pkg"_*.deb |
-            tar xf - ./sbin/ub-device-create ./lib/udev/rules.d/71-nvidia.rules
+            tar xf - \
+                ./sbin/ub-device-create \
+                ./lib/udev/rules.d/71-nvidia.rules \
+                ./etc/modprobe.d/nvidia-graphics-drivers-kms.conf
         rm "$nvidia_common_pkg"_*.deb
         ;;
 esac


### PR DESCRIPTION
Backport of https://github.com/canonical/core-base/pull/273