### PR TITLE
console-conf: work around dh_installsystemd not enabling template units

### DIFF
--- a/static/usr/lib/systemd/system/getty.target.wants/console-conf@tty1.service
+++ b/static/usr/lib/systemd/system/getty.target.wants/console-conf@tty1.service
@@ -1,0 +1,1 @@
+../console-conf@.service


### PR DESCRIPTION
dh_installsystemd assumes that template units cannot be enabled. That is not true. Units with DefaultInstance can be enabled. And this is the case for console-conf@service. So instead we manually install it with a symlink.

This should not affect core24 or later.