### PR TITLE
hooks: remove check for injecting FIPS PPA

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -92,12 +92,8 @@ EOF
 
 # write FIPS PPA files if the current build is a FIPS build
 if [[ ${SNAP_FIPS_BUILD+x} ]]; then
-    # for private builds a conf file is neccessary, setup for PPA access
-    # if provided
-    if [ -e etc/apt/auth.conf.d/01-fips.conf ]; then
-        # add fips personal token
-        echo "deb https://private-ppa.launchpadcontent.net/ubuntu-advantage/pro-fips-updates/ubuntu $CODENAME main" > /etc/apt/sources.list.d/fips.list
-        cat >etc/apt/trusted.gpg.d/fips-cc-stig.asc <<'EOF'
+    echo "deb https://private-ppa.launchpadcontent.net/ubuntu-advantage/pro-fips-updates/ubuntu $CODENAME main" > /etc/apt/sources.list.d/fips.list
+    cat >etc/apt/trusted.gpg.d/fips-cc-stig.asc <<'EOF'
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Comment: Hostname: 
 Version: Hockeypuck 2.2
@@ -141,7 +137,6 @@ Dyi6+RIJ+lHVuuiZH3fqNER795RdpLHKLpgj4kO6ywfeliM3qLeJMWulTHvt6bUY
 =1S42
 -----END PGP PUBLIC KEY BLOCK-----
 EOF
-    fi
 
     mkdir -p etc/apt/preferences.d/
     cat >etc/apt/preferences.d/fips.pref <<'EOF'


### PR DESCRIPTION
Backport of https://github.com/canonical/core-base/pull/276 for core22