### PR TITLE
Add internal source url

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -120,6 +120,8 @@ EOF
 # write FIPS PPA files if the current build is a FIPS build
 if [[ ${SNAP_FIPS_BUILD+x} ]]; then
     echo "deb https://private-ppa.launchpadcontent.net/fips-cc-stig/fips-under-certification/ubuntu $CODENAME main" > /etc/apt/sources.list.d/fips.list
+    # this allow launchpad intenal build access private ppa without credentials
+    echo "deb http://private-ppa.buildd/fips-cc-stig/fips-under-certification/ubuntu $CODENAME main" >> /etc/apt/sources.list.d/fips.list
     cat >etc/apt/trusted.gpg.d/fips-cc-stig.asc <<'EOF'
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Comment: Hostname: 

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -119,9 +119,13 @@ EOF
 
 # write FIPS PPA files if the current build is a FIPS build
 if [[ ${SNAP_FIPS_BUILD+x} ]]; then
-    echo "deb https://private-ppa.launchpadcontent.net/fips-cc-stig/fips-under-certification/ubuntu $CODENAME main" > /etc/apt/sources.list.d/fips.list
-    # this allow launchpad intenal build access private ppa without credentials
-    echo "deb http://private-ppa.buildd/fips-cc-stig/fips-under-certification/ubuntu $CODENAME main" >> /etc/apt/sources.list.d/fips.list
+    # for private builds a conf file is neccessary, setup for PPA access if provided
+    if [ -e etc/apt/auth.conf.d/01-fips.conf ]; then
+        echo "deb https://private-ppa.launchpadcontent.net/fips-cc-stig/fips-under-certification/ubuntu $CODENAME main" > /etc/apt/sources.list.d/fips.list
+    else
+        # this allow launchpad intenal build access private ppa without credentials
+        echo "deb http://private-ppa.buildd/fips-cc-stig/fips-under-certification/ubuntu $CODENAME main" >> /etc/apt/sources.list.d/fips.list
+    fi
     cat >etc/apt/trusted.gpg.d/fips-cc-stig.asc <<'EOF'
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Comment: Hostname: 


### PR DESCRIPTION
### Description

- Allow launchpad intenal build access private ppa without credentials

### Rational

- According to the lp building log:

```
RUN: /usr/share/launchpad-buildd/bin/in-target override-sources-list --backend=lxd --series=noble --arch=amd64 SNAPBUILD-2655127 'deb http://private-ppa.buildd/fips-cc-stig/fips-under-certification/ubuntu noble main' 'deb http://ftpmaster.internal/ubuntu noble main universe' 'deb http://ftpmaster.internal/ubuntu noble-security main universe'
```

The builder **automatically** add "http://private-ppa.buildd" as the source list for current ppa. So I give a shot here to see if this solve the access problem. 

- I also tried to reproduce locally with the launchpad-buildd following the log, the "private-ppa.buildd" and "http://ftpmaster.internal/" failed to resolved as expected and I bet it the missing part of our building configuration.

### To-do

- Backport to core22 branch if this works