### PR TITLE
hooks(core22): do not remove libapt for now

### DIFF
--- a/hooks/600-no-debian.chroot
+++ b/hooks/600-no-debian.chroot
@@ -7,7 +7,11 @@ set -ex
 echo "I: Removing the debian legacy"
 
 # dpkg-deb and dpkg purposefully left behind
-dpkg --purge --force-depends apt libapt-pkg6.0 debconf
+# leave libapt6.0 behind for now, it's unfortunately currently imported
+# by the snapcraft snap. See https://github.com/canonical/core-base/issues/283.
+# we have been carrying this library since core20 because of a we never updated
+# the library name (we were removing libapt5.0 which did not exist).
+dpkg --purge --force-depends apt debconf
 
 # store manifest of all installed packages
 install -m755 -d usr/share/snappy


### PR DESCRIPTION
See https://github.com/canonical/core-base/issues/283 and the comment for the change.

I don't think its the right choice for the snapcraft snap to be importing this. On Chisel there will be no apt environment at all, and they cannot even assume any `apt` presence. I think we should file a bug for snapcraft to stop importing this, or atleast make them resistent to this. (See https://github.com/canonical/snapcraft/issues/5146)