### PR TITLE
hooks(core24): keep libapt around for now

### DIFF
--- a/hooks/600-no-debian.chroot
+++ b/hooks/600-no-debian.chroot
@@ -6,8 +6,11 @@ set -ex
 
 echo "I: Removing the debian legacy"
 
-# dpkg-deb and dpkg purposefully left behind
-dpkg --purge --force-depends apt libapt-pkg6.0t64 debconf
+# leave libapt6.0 behind for now, it's unfortunately currently imported
+# by the snapcraft snap. See https://github.com/canonical/core-base/issues/283.
+# we have been carrying this library since core20 because of a we never updated
+# the library name (we were removing libapt5.0 which did not exist).
+dpkg --purge --force-depends apt debconf
 
 # store manifest of all installed packages
 install -m755 -d usr/share/snappy


### PR DESCRIPTION
See https://github.com/canonical/core-base/issues/283 and the comment for the change.

I don't think its the right choice for the snapcraft snap to be importing this. On Chisel there will be no apt environment at all, and they cannot even assume any apt presence. Filed a bug for Snapcraft: https://github.com/canonical/snapcraft/issues/5146