### PR TITLE
[core22] FIPS packages: Add ssh

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -234,7 +234,7 @@ if [[ ${SNAP_FIPS_BUILD+x} ]]; then
     # Ensure vital crypt packages are refreshed / downgraded and downloaded
     # from the FIPS ppa. This should also contain openssh-server, but we already
     # have that one listed above.
-    PACKAGES+=(libgcrypt20 libgnutls30 openssl-fips-module-3)
+    PACKAGES+=(libgcrypt20 libgnutls30 openssl-fips-module-3 ssh)
     apt-get install --no-install-recommends --allow-downgrades -y "${PACKAGES[@]}"
 else
     apt-get install --no-install-recommends -y "${PACKAGES[@]}"


### PR DESCRIPTION
### Description

- Add openssh to install the fips-variant ssh
- Cherry-pick from #282 

### Rationale

- The normal openssh has issue to work properly with fips kernel snap