### PR TITLE
hooks: always write the FIPS preference for FIPS builds

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -118,7 +118,7 @@ FSbrQ9ACQFlqN49Ogbl47J6TZ7BrjDpROote55ixmrU=
 EOF
 
 # write FIPS PPA files if the current build is a local FIPS build
-# for private builds a conf file is neccessary, setup for PPA access if provided
+# for private builds a conf file is necessary, setup for PPA access if provided
 if [ -e etc/apt/auth.conf.d/01-fips.conf ]; then
     echo "deb https://private-ppa.launchpadcontent.net/fips-cc-stig/fips-under-certification/ubuntu $CODENAME main" > /etc/apt/sources.list.d/fips.list
     cat >etc/apt/trusted.gpg.d/fips-cc-stig.asc <<'EOF'
@@ -153,7 +153,11 @@ UNuHk+m6RrdnU0GhZFiccabKzM11OElMcupvOQeIRA==
 =MKdQ
 -----END PGP PUBLIC KEY BLOCK-----
 EOF
-  
+fi
+
+# always install the preference though, both for LP and
+# local
+if [[ ${SNAP_FIPS_BUILD+x} ]]; then
     mkdir -p etc/apt/preferences.d/
     cat >etc/apt/preferences.d/fips.pref <<'EOF'
 Package: *


### PR DESCRIPTION
While we fixed the FIPS build, and correctly can access the PPA - it seems I was missing this commit for our upstream version. This uses the correct pinning for FIPS builds.