### PR TITLE
tests: log spread failures to grafana

### DIFF
--- a/.github/actions/run-spread-tests/action.yaml
+++ b/.github/actions/run-spread-tests/action.yaml
@@ -16,9 +16,11 @@ runs:
     shell: bash
     run: |
         # Configure parameters to filter logs (these logs are sent read by grafana agent)
-        CHANGE_ID="${{ github.event.number }}"
-        if [ -z "$CHANGE_ID" ]; then
-          CHANGE_ID="main"
+        
+        if [ "${{ github.event.pull_request }}" ]; then
+          CHANGE_ID="${{ github.event.pull_request.base.ref }}_pr_${{ github.event.number }}"
+        else
+          CHANGE_ID="${{ github.ref_name }}"
         fi
         FILTERED_LOG_FILE="${{ github.workspace }}/spread_${CHANGE_ID}_n${{ github.run_attempt }}.filtered.log"
         echo FILTERED_LOG_FILE="$FILTERED_LOG_FILE"  >> $GITHUB_ENV

--- a/.github/actions/run-spread-tests/action.yaml
+++ b/.github/actions/run-spread-tests/action.yaml
@@ -29,7 +29,7 @@ runs:
         echo "GRAFANA START: pr ${CHANGE_ID} attempt ${{ github.run_attempt }} run ${{ github.run_id }}" > "$FILTERED_LOG_FILE"
 
   - name: Checkout snapd-testing-tools
-    uses: actions/checkout@v2
+    uses: actions/checkout@v4
     with:
       repository: canonical/snapd-testing-tools
       path: snapd-testing-tools

--- a/.github/actions/run-spread-tests/action.yaml
+++ b/.github/actions/run-spread-tests/action.yaml
@@ -28,6 +28,12 @@ runs:
         # Add start line to filtered log
         echo "GRAFANA START: pr ${CHANGE_ID} attempt ${{ github.run_attempt }} run ${{ github.run_id }}" > "$FILTERED_LOG_FILE"
 
+  - name: Checkout snapd-testing-tools
+    uses: actions/checkout@v2
+    with:
+      repository: canonical/snapd-testing-tools
+      path: snapd-testing-tools
+
   - name: Run spread
     shell: bash
     run: |
@@ -35,7 +41,7 @@ runs:
       (
         set -o pipefail
         ${{ inputs.spread-command }} | \
-          ./tests/lib/external/snapd-testing-tools/utils/log-filter -o $FILTERED_LOG_FILE -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES | \
+          ${{ github.workspace }}/snapd-testing-tools/utils/log-filter -o $FILTERED_LOG_FILE -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES | \
           tee spread.log
       )
 
@@ -47,7 +53,7 @@ runs:
       if [ -e spread.log ]; then
         echo "Running spread log analyzer"
         ACTIONS_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
-        ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --output spread-results.json --cut 1 >/dev/null
+        ${{ github.workspace }}/utils/log-parser spread.log --output spread-results.json --cut 1 >/dev/null
         while IFS= read -r line; do
             if [ ! -z "$line" ]; then
                 echo "Adding failed test line to filtered log"

--- a/.github/actions/run-spread-tests/action.yaml
+++ b/.github/actions/run-spread-tests/action.yaml
@@ -53,7 +53,7 @@ runs:
       if [ -e spread.log ]; then
         echo "Running spread log analyzer"
         ACTIONS_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
-        ${{ github.workspace }}/utils/log-parser spread.log --output spread-results.json --cut 1 >/dev/null
+        ${{ github.workspace }}/snapd-testing-tools/utils/log-parser spread.log --output spread-results.json --cut 1 >/dev/null
         while IFS= read -r line; do
             if [ ! -z "$line" ]; then
                 echo "Adding failed test line to filtered log"

--- a/.github/actions/run-spread-tests/action.yaml
+++ b/.github/actions/run-spread-tests/action.yaml
@@ -1,0 +1,59 @@
+name: 'Run spread command with Grafana logging'
+inputs:
+  working-directory:
+    required: false
+    default: ./
+    type: string
+  spread-command:
+    description: Complete spread command to run i.e. spread google-nested:tests/spread/main/
+    required: true
+    type: string
+    
+runs:
+  using: "composite"
+  steps:
+  - name: Setup grafana parameters
+    shell: bash
+    run: |
+        # Configure parameters to filter logs (these logs are sent read by grafana agent)
+        CHANGE_ID="${{ github.event.number }}"
+        if [ -z "$CHANGE_ID" ]; then
+          CHANGE_ID="main"
+        fi
+        FILTERED_LOG_FILE="${{ github.workspace }}/spread_${CHANGE_ID}_n${{ github.run_attempt }}.filtered.log"
+        echo FILTERED_LOG_FILE="$FILTERED_LOG_FILE"  >> $GITHUB_ENV
+
+        # Add start line to filtered log
+        echo "GRAFANA START: pr ${CHANGE_ID} attempt ${{ github.run_attempt }} run ${{ github.run_id }}" > "$FILTERED_LOG_FILE"
+
+  - name: Run spread
+    shell: bash
+    run: |
+      cd "${{ inputs.working-directory }}"
+      (
+        set -o pipefail
+        ${{ inputs.spread-command }} | \
+          ./tests/lib/external/snapd-testing-tools/utils/log-filter -o $FILTERED_LOG_FILE -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES | \
+          tee spread.log
+      )
+
+  - name: Write log for Grafana
+    if: always()
+    shell: bash
+    run: |
+      cd "${{ inputs.working-directory }}"
+      if [ -e spread.log ]; then
+        echo "Running spread log analyzer"
+        ACTIONS_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+        ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --output spread-results.json --cut 1 >/dev/null
+        while IFS= read -r line; do
+            if [ ! -z "$line" ]; then
+                echo "Adding failed test line to filtered log"
+                echo "GRAFANA FAILED: $line $ACTIONS_URL" | tee -a "$FILTERED_LOG_FILE"
+            fi
+        done <<< $(jq -r '.[] | select( .type == "info" ) | select( .info_type == "Error" ) | "\(.verb) \(.task)"' spread-results.json)
+      else
+        echo "No spread log found, skipping errors reporting"
+      fi
+
+      

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,10 @@ on:
       - main
       - 'core[0-9][0-9]'
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: self-hosted
@@ -60,14 +64,16 @@ jobs:
         with:
           name: core-snap
           path: "${{ github.workspace }}/core24.artifact"
-      
+
       - name: Run x86 tests
-        run: |
-          spread google-nested:tests/spread/main/
+        uses: ./.github/actions/run-spread-tests
+        with:
+          spread-command: spread google-nested:tests/spread/main/
 
       - name: Run arm64 tests
-        run: |
-          spread-arm google-nested-arm:tests/spread/main/
+        uses: ./.github/actions/run-spread-tests
+        with:
+          spread-command: spread-arm google-nested-arm:tests/spread/main/
 
       - name: Discard spread workers
         if: always()
@@ -125,10 +131,11 @@ jobs:
           echo "************* STARTING CORE24 VM *************"
           start_snapd_core_vm '${{ github.workspace }}'
 
-          cd snapd
-
-          # add any test suites that should be tested here
-          SPREAD_EXTERNAL_ADDRESS=localhost:8022 spread external:ubuntu-core-24-64:tests/smoke/
+      - name: Run snapd spread
+        uses: ./core-base/.github/actions/run-spread-tests
+        with:
+          working-directory: snapd
+          spread-command: SPREAD_EXTERNAL_ADDRESS=localhost:8022 spread external:ubuntu-core-24-64:tests/smoke/
 
       - name: Discard spread workers
         if: always()


### PR DESCRIPTION
Logs spread failures to Grafana and also updates the snapd-test-tools to permit the use of the same tools used in snapd