### PR TITLE
console-conf: make exit status 22 not reported as a failure

### DIFF
--- a/static/usr/lib/systemd/system/console-conf@.service.d/fix.conf
+++ b/static/usr/lib/systemd/system/console-conf@.service.d/fix.conf
@@ -1,0 +1,4 @@
+[Service]
+SuccessExitStatus=22
+ExecStopPost=
+ExecStopPost=/usr/share/subiquity/console-conf-check-error-fix getty@%i.service

--- a/static/usr/lib/systemd/system/serial-console-conf@.service.d/fix.conf
+++ b/static/usr/lib/systemd/system/serial-console-conf@.service.d/fix.conf
@@ -1,0 +1,4 @@
+[Service]
+SuccessExitStatus=22
+ExecStopPost=
+ExecStopPost=/usr/share/subiquity/console-conf-check-error-fix serial-getty@%i.service

--- a/static/usr/share/subiquity/console-conf-check-error-fix
+++ b/static/usr/share/subiquity/console-conf-check-error-fix
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+if [ "${SERVICE_RESULT}" == "success" ] && [ "${EXIT_STATUS}" -eq 22 ]; then
+  systemctl start --no-block "${1}"
+fi


### PR DESCRIPTION
This is a quick fix that should be applied to upstream.

24 and main will also need a similar fix.