### PR TITLE
hooks: add back some python dependencies

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -211,6 +211,8 @@ PACKAGES=(
     p11-kit-modules
     plymouth-label-ft
     polkitd
+    python3-dbus
+    python3-netifaces
     rfkill
     squashfs-tools
     sudo

--- a/spread.yaml
+++ b/spread.yaml
@@ -24,8 +24,7 @@ backends:
     systems:
       - ubuntu-24.04-64:
           workers: 4
-          # FIXME: switch to 24.04
-          image: ubuntu-23.10-64
+          image: ubuntu-24.04-64
           storage: 20G
 
   google-nested-arm:

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -120,9 +120,9 @@ start_nested_core_vm_unit(){
         fi
         QEMU_BIN=qemu-system-x86_64
         PARAM_MACHINE="-machine q35${ATTR_KVM} -global ICH9-LPC.disable_s3=1"
-        PARAM_BIOS="-drive file=/usr/share/OVMF/OVMF_CODE${VMF_CODE}.fd,if=pflash,format=raw,unit=0,readonly=on -drive file=${WORK_DIR}/image/OVMF_VARS${VMF_VARS}.fd,if=pflash,format=raw"
+        PARAM_BIOS="-drive file=/usr/share/OVMF/OVMF_CODE_4M${VMF_CODE}.fd,if=pflash,format=raw,unit=0,readonly=on -drive file=${WORK_DIR}/image/OVMF_VARS_4M${VMF_VARS}.fd,if=pflash,format=raw"
         TPM_DEVICE=tpm-tis
-        cp -f "/usr/share/OVMF/OVMF_VARS${VMF_VARS}.fd" "${WORK_DIR}/image/OVMF_VARS${VMF_VARS}.fd"
+        cp -f "/usr/share/OVMF/OVMF_VARS_4M${VMF_VARS}.fd" "${WORK_DIR}/image/OVMF_VARS_4M${VMF_VARS}.fd"
     elif os.query is-arm64; then
         # Assume arm64
         # Unfortunately gce does not offer kvm enabled arm64 VMs

--- a/tests/lib/prepare-utils.sh
+++ b/tests/lib/prepare-utils.sh
@@ -76,8 +76,8 @@ start_snapd_core_vm() {
     fi
 
     mkdir -p "${work_dir}/image/"
-    cp -f "/usr/share/OVMF/OVMF_VARS.fd" "${work_dir}/image/OVMF_VARS.fd"
-    PARAM_BIOS="-drive file=/usr/share/OVMF/OVMF_CODE.fd,if=pflash,format=raw,unit=0,readonly=on -drive file=${work_dir}/image/OVMF_VARS.fd,if=pflash,format=raw"
+    cp -f "/usr/share/OVMF/OVMF_VARS_4M.fd" "${work_dir}/image/OVMF_VARS_4M.fd"
+    PARAM_BIOS="-drive file=/usr/share/OVMF/OVMF_CODE_4M.fd,if=pflash,format=raw,unit=0,readonly=on -drive file=${work_dir}/image/OVMF_VARS_4M.fd,if=pflash,format=raw"
     PARAM_MACHINE="-machine q35${ATTR_KVM} -global ICH9-LPC.disable_s3=1"
     PARAM_IMAGE="-drive file=${work_dir}/pc.img,cache=none,format=raw,id=disk1,if=none -device virtio-blk-pci,drive=disk1,bootindex=1"
 


### PR DESCRIPTION
Some netplan/subiquity dependencies have changed and some python packages are not neded anymore. Get them back as otherwise we might be breaking the API for apps using this base.