### PR TITLE
Makefile: remove the quotes around CODENAME and reintroduce jammy-updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TESTDIR ?= "prime/"
 SNAP_NAME=core22
 SNAP_BUILD_NAME=core22
 SNAP_CORE_TRACK:=latest
-CODENAME:="$(shell . /etc/os-release; echo "$$VERSION_CODENAME")"
+CODENAME:=$(shell . /etc/os-release; echo "$$VERSION_CODENAME")
 
 # include any fips environmental setup if the file exists.
 # Variables:
@@ -53,7 +53,11 @@ ifdef SNAP_FIPS_BUILD
 	if [ -e ./fips.conf ]; then \
 		mkdir -p $(DESTDIR)/etc/apt/auth.conf.d/; \
 		cp ./fips.conf $(DESTDIR)/etc/apt/auth.conf.d/01-fips.conf; \
-	fi    
+	fi
+
+	# If we are doing a fips build, make sure updates are enabled
+	# and we export that to the hooks
+	sed -n 's/$(CODENAME)-security/$(CODENAME)-updates/p' /etc/apt/sources.list >> $(DESTDIR)/etc/apt/sources.list;
 
 endif
 	mkdir -p $(DESTDIR)/install-data


### PR DESCRIPTION
### Rationale:

- As from the [log](https://i770926049.restricted.launchpadlibrarian.net/770926049/buildlog_snap_ubuntu_jammy_amd64_core22-fips_BUILDING.txt.gz?token=RxnJxZgRRK5Zm3d6MwVKQr17zXmLqzmb) the Makefile will execute command `:: sed -n 's/"jammy"-security/"jammy"-updates/p' /etc/apt/sources.list >> /build/core22/parts/bootstrap/install/etc/apt/sources.list;`
which sed will treat "jammy" as-is so the replacement never happens.

- reason that core22 fail to build while core24 succeed with the same Makefile line:
the image core22 download is: https://cdimage.ubuntu.com/ubuntu-base/jammy/daily/current/jammy-base-amd64.tar.gz which only has jammy and jammy-security (expected)
the image core24 download is: https://cdimage.ubuntu.com/ubuntu-base/releases/24.04/release/ubuntu-base-24.04.1-base-amd64.tar.gz which already contain jammy, jammy-update, jammy-security

### Reproduce:

- Create a Makefile:
```make
CODENAME:="$(shell . /etc/os-release; echo "$$VERSION_CODENAME")"
#CODENAME:=$(shell . /etc/os-release; echo "$$VERSION_CODENAME")

# Print the detected OS codename
print-codename:
        sed  -n 's/$(CODENAME)-security/$(CODENAME)-updates/p' /etc/apt/sources.list > /tmp/ok
        @echo "OS Codename: $(CODENAME)"

# Example target (optional)
all: print-codename
        @echo "Build/other tasks can go here."

# Cleanup (optional)
clean:
        @echo "Cleaning up..."

# Mark targets that don't produce files as phony
.PHONY: print-codename all clean
```
- run `make print-codename`
- `cat /tmp/ok`