### PR TITLE
hooks: copy the desired default font to Plymouth.ttf

### DIFF
--- a/hooks/026-configure-plymouth.chroot
+++ b/hooks/026-configure-plymouth.chroot
@@ -33,7 +33,7 @@ EOF
 
 # Leave only the font used by ubuntu-core theme
 rm -rf /usr/share/fonts/truetype/dejavu/
-mv /usr/share/fonts/truetype/ubuntu/Ubuntu-R.ttf /usr/share/fonts/Plymouth.ttf
+cp '/usr/share/fonts/truetype/ubuntu/Ubuntu[wdth,wght].ttf' /usr/share/fonts/Plymouth.ttf
 rm -rf /usr/share/fonts/truetype/ubuntu/
 
 # We pull by "Wants" instead, so these units are not run unless plymouth-start is


### PR DESCRIPTION
Previously we were moving, but now in noble Ubuntu-R.ttf was actually a link to Ubuntu[wdth,wght].ttf, so actually a symlink to a non-present file was created. Instead, copy the file that we have now, which will also fix the issue if in the future it becomes a symlink too.

Backport of https://github.com/canonical/core-base/pull/306