### PR TITLE
hooks: remove sub directories and symlinks from /usr/share/doc

### DIFF
--- a/hooks/608-cleanup-usr-share-doc.chroot
+++ b/hooks/608-cleanup-usr-share-doc.chroot
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Remove /usr/share/doc sub directories and symlinks which were pulled in from
+# multiple packages
+
+set -xe
+
+echo "I: Removing /usr/share/doc sub directories and symlinks"
+
+find /usr/share/doc/ -mindepth 1 -maxdepth 1 -type d -exec rm -rv {} +
+find /usr/share/doc/ -mindepth 1 -maxdepth 1 -type l -exec rm -v {} +


### PR DESCRIPTION
Docs are mostly dead weight in the core artifact:

```
$ du -shc /snap/core24/current/usr/share/doc/
2.6M	/snap/core24/current/usr/share/doc/
2.6M	total
```