### PR TITLE
hooks: avoid conffile prompt from installing base-files

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -172,9 +172,9 @@ apt-get update
 # when doing a FIPS build we will allow downgrades due to package
 # versions possibly being lower in the FIPS ppa
 if [[ ${SNAP_FIPS_BUILD+x} ]]; then
-    apt-get dist-upgrade -y --allow-downgrades
+    apt-get dist-upgrade -y --allow-downgrades -o Dpkg::Options::="--force-confnew"
 else
-    apt-get dist-upgrade -y
+    apt-get dist-upgrade -y -o Dpkg::Options::="--force-confnew"
 fi
 
 PACKAGES=(


### PR DESCRIPTION
The building log:
```
Preparing to unpack .../base-files_13ubuntu10.2_arm64.deb ...
:: Unpacking base-files (13ubuntu10.2) over (13ubuntu10.1) ...
:: Setting up base-files (13ubuntu10.2) ...
::
:: Configuration file '/etc/issue'
::  ==> Modified (by you or by a script) since installation.
::  ==> Package distributor has shipped an updated version.
::    What would you like to do about it ?  Your options are:
::     Y or I  : install the package maintainer's version
::     N or O  : keep your currently-installed version
::       D     : show the differences between the versions
::       Z     : start a shell to examine the situation
::  The default action is to keep your current version.
:: *** issue (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package base-files (--configure):
::  end of file on stdin at conffile prompt
:: Errors were encountered while processing:
::  base-files
:: E: Sub-process /usr/bin/dpkg returned an error code (1)
```
indicates the prompt is introduced by install base-files and not receiving any input since building is non-interactive. So add an option to choose the maintainer's version one since I find no modification on /etc/issue