### PR TITLE
main: revert pam.d workaround

### DIFF
--- a/hook-tests/031-faillock.test
+++ b/hook-tests/031-faillock.test
@@ -2,4 +2,4 @@
 
 set -eu
 
-grep pam_faillock.so usr/lib/pam.d/common-auth
+grep pam_faillock.so etc/pam.d/common-auth

--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -17,18 +17,7 @@ rm -rvf /etc/selinux
 rm -rvf /etc/binfmt.d
 rm /etc/gai.conf
 rm /etc/debian_version
-
 rm /etc/pam.conf
-
-# move pam.d files from /etc/pam.d to /usr/lib/pam.d to allow snaps
-# to mount on top and provide their own.
-mv etc/pam.d/* usr/lib/pam.d
-
-# Prefix all includes with /usr/lib/pam.d for now, we have to do this unfortunately
-# due to a bug in the debian patch for @includes.
-# See filed bug: https://bugs.launchpad.net/ubuntu/+source/pam/+bug/2087827
-# XXX: Remove this line once its fixed upstream
-find usr/lib/pam.d/ -type f -exec sed -i -e 's/\@include /\@include \/usr\/lib\/pam.d\//g' {} \;
 
 # cloud-init adds stuff here
 rm -rvf /etc/profile.d/Z99-cloud*

--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -27,17 +27,8 @@ mv etc/pam.d/* usr/lib/pam.d
 # Prefix all includes with /usr/lib/pam.d for now, we have to do this unfortunately
 # due to a bug in the debian patch for @includes.
 # See filed bug: https://bugs.launchpad.net/ubuntu/+source/pam/+bug/2087827
-# XXX: Remove these two replacements once its fixed upstream
+# XXX: Remove this line once its fixed upstream
 find usr/lib/pam.d/ -type f -exec sed -i -e 's/\@include /\@include \/usr\/lib\/pam.d\//g' {} \;
-# Also handle the other include file format. There are currently two different types of includes
-# `include` (inside files postfixed with -l) and @include, which can appear in all the other types
-# of files.
-for file in usr/lib/pam.d/*-l;
-do
-    echo "replacing pam.d includes in $file"
-    awk ' BEGIN{OFS="\t"} { if($2 == "include") $3="/usr/lib/pam.d/"$3; print } ' "$file" > "$file.tmp"
-    mv "$file.tmp" "$file"
-done
 
 # cloud-init adds stuff here
 rm -rvf /etc/profile.d/Z99-cloud*


### PR DESCRIPTION
This broke pam.d profiles that came with snaps since they load using relative paths. Relative paths do not work correctly right now and only expect profiles to exist in /etc/pam.d.

Forward-ported from https://github.com/canonical/core-base/pull/324