### PR TITLE
hooks: add systemd-zram-generator

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -219,6 +219,7 @@ PACKAGES=(
     systemd-sysv
     systemd-timesyncd
     systemd-resolved
+    systemd-zram-generator
     tzdata
     udev
     vim-tiny

--- a/hooks/032-systemd-zram-generator.chroot
+++ b/hooks/032-systemd-zram-generator.chroot
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eux
+
+mkdir -p /usr/lib/systemd/zram-generator.conf.d
+mv /etc/systemd/zram-generator.conf /usr/lib/systemd/zram-generator.conf.d/ram0.conf
+
+mkdir -p /usr/lib/modules-load.d
+mv /etc/modules-load.d/20-zram-generator.conf /usr/lib/modules-load.d/20-zram-generator.conf


### PR DESCRIPTION
This add a swap of compressed ram as /dev/zram0. This can be disabled in the kernel command-line with `systemd.zram=0`.

```
valentin.david@ubuntu:~$ swapon 
NAME       TYPE      SIZE USED PRIO
/dev/zram0 partition   4G   0B  100
valentin.david@ubuntu:~$ 
```
