### PR TITLE
many: put default motd in /usr

### DIFF
--- a/hook-tests/008-etc-writable.test
+++ b/hook-tests/008-etc-writable.test
@@ -5,7 +5,6 @@ set -e
 echo "Ensure links worked"
 test -e etc/localtime
 test -e etc/hostname
-test -e etc/motd
 test -e etc/issue
 test $(readlink etc/localtime) = "writable/localtime"
 test $(readlink etc/writable/localtime) = "/usr/share/zoneinfo/Etc/UTC"
@@ -13,3 +12,4 @@ test $(readlink etc/writable/localtime) = "/usr/share/zoneinfo/Etc/UTC"
 echo "Ensure writable dirs are available"
 test -d etc/systemd/system.conf.d
 test -d etc/systemd/user.conf.d
+test -d etc/motd.d

--- a/hook-tests/014-set-motd.test
+++ b/hook-tests/014-set-motd.test
@@ -2,12 +2,15 @@
 
 set -e
 
-grep -q "Welcome to Ubuntu Core 24" etc/motd
+grep -q "Welcome to Ubuntu Core 24" usr/lib/motd.d/50-default
 
 test ! -e etc/default/motd-news
-test ! -e etc/update-motd.d/00-header
-test ! -e etc/update-motd.d/10-help-text
 test ! -e usr/lib/systemd/system/motd-news.service
 test ! -e usr/lib/systemd/system/motd-news.timer
 
-! grep -q unminimize etc/update-motd.d/*
+# Checks for empty update-motd.d - for future bases this will be a canary to
+# check if we need to leave anything new there.
+# shellcheck disable=SC2034 # read needs a variable
+if find etc/update-motd.d -mindepth 1 -maxdepth 1 | read -r var
+then exit 1
+fi

--- a/hooks/008-etc-writable.chroot
+++ b/hooks/008-etc-writable.chroot
@@ -4,7 +4,7 @@ mkdir -p /etc/writable/default
 
 # cloud-init needs to be able to modify hostname and has the ability to
 # set the other two.
-for f in localtime hostname motd issue; do
+for f in localtime hostname issue; do
     if [ -e /etc/$f ]; then
         echo "I: Moving /etc/$f to /etc/writable/"
         mv /etc/$f /etc/writable/$f

--- a/hooks/014-set-motd.chroot
+++ b/hooks/014-set-motd.chroot
@@ -1,27 +1,9 @@
 #!/bin/bash -ex
 
-cat >/etc/motd<<EOF
-Welcome to Ubuntu Core 24
+# The default motd message is in static/usr/lib/motd.d/50-default
 
-* Documentation: https://ubuntu.com/core/docs
-
-This is a pre-built Ubuntu Core image. Pre-built images are ideal for
-exploration as you develop your own custom Ubuntu Core image.
-
-To learn how to create your custom Ubuntu Core image, see our guide:
-
-* Getting Started: https://ubuntu.com/core/docs/get-started
-
-In this image, why not create an IoT web-kiosk. First, connect a 
-screen, then run: 
-
-   snap install ubuntu-frame wpe-webkit-mir-kiosk
-   snap set wpe-webkit-mir-kiosk url=https://ubuntu.com/core
-
-For more ideas, visit:
-
-* First steps: https://ubuntu.com/core/docs/first-steps
-EOF
+# For overrides / additional messages
+mkdir -p /etc/motd.d
 
 # remove update-motd bits which clash with /etc/motd content
 # in particular the 'help' and the 'welcome' messages.
@@ -31,6 +13,9 @@ rm /etc/update-motd.d/10-help-text
 # Core systems cannot be unminimized, despite being built from
 # minimal-classic tarball
 rm /etc/update-motd.d/60-unminimize
+
+# This one does something only if motd-news is enabled
+rm /etc/update-motd.d/50-motd-news
 
 # remove the motd-news service files
 rm /lib/systemd/system/motd-news.{service,timer}

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -65,7 +65,8 @@
 # allow system wide proxy setting
 /etc/environment                        auto                    persistent  transition  none
 /etc/machine-id                         auto                    persistent  transition  none
-# make update-motd writable for branding purposes
+# make motd.d and update-motd.d writable for branding purposes
+/etc/motd.d                             auto                    persistent  transition  none
 /etc/update-motd.d                      auto                    persistent  transition  none
 # allow to update password policy
 /etc/security/pwquality.conf            auto                    persistent  transition  none

--- a/static/usr/lib/motd.d/50-default
+++ b/static/usr/lib/motd.d/50-default
@@ -1,0 +1,20 @@
+Welcome to Ubuntu Core 24
+
+* Documentation: https://ubuntu.com/core/docs
+
+This is a pre-built Ubuntu Core image. Pre-built images are ideal for
+exploration as you develop your own custom Ubuntu Core image.
+
+To learn how to create your custom Ubuntu Core image, see our guide:
+
+* Getting Started: https://ubuntu.com/core/docs/get-started
+
+In this image, why not create an IoT web-kiosk. First, connect a
+screen, then run:
+
+   snap install ubuntu-frame wpe-webkit-mir-kiosk
+   snap set wpe-webkit-mir-kiosk url=https://ubuntu.com/core
+
+For more ideas, visit:
+
+* First steps: https://ubuntu.com/core/docs/first-steps


### PR DESCRIPTION
Instead of having a symlink in /etc/motd that points to a writable path, put the default motd in /usr/lib/motd.d/50-default file, and add /etc/motd.d to the writable paths. With this

- When remodeling, we will show the message from the new base as it is part of the immutable directories.

- It is still possible to override the default message by creating a file named /etc/motd.d/50-default.

- It is also possible to add messages by creating additional files in /etc/motd.d/ or by adding scripts to /etc/update-motd.d/ as in the past.

Backport of https://github.com/canonical/core-base/pull/332