### PR TITLE
hooks: write default configuration for vconsole.conf

### DIFF
--- a/hook-tests/010-locale-vconsole-symlinks.test
+++ b/hook-tests/010-locale-vconsole-symlinks.test
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eux
+
+# ensure link is readable
+grep "LANG" etc/locale.conf
+
+# ensure link is readable
+grep "KEYMAP" etc/vconsole.conf

--- a/hooks/010-locale-vconsole-symlinks.chroot
+++ b/hooks/010-locale-vconsole-symlinks.chroot
@@ -9,7 +9,9 @@ ln -s ../writable/locale.conf /etc/default/locale
 ln -s writable/locale.conf /etc/locale.conf
 
 # setup default vconsole/keyboard configuration, make it a
-# symlink as well so it can change
-mv /etc/vconsole.conf /etc/writable/vconsole.conf
+# symlink as well so it can change, and remove the default
+# symlink (/etc/vconsole.conf => default/keyboard)
+rm /etc/vconsole.conf
+printf 'KEYMAP=us\n' > /etc/writable/vconsole.conf
 ln -s ../writable/vconsole.conf /etc/default/keyboard
 ln -s writable/vconsole.conf /etc/vconsole.conf


### PR DESCRIPTION
The default shipped /etc/vconsole.conf is a symlink to default/keyboard, which is non-existant in the default setup. The default configuration is just to default to US keymap.

Add a test as my previous testing was obviously insufficient, and this fixes a weird symlink loop that was introduced earlier.