### PR TITLE
hooks: make sure that the ssh.socket unit is enabled

### DIFF
--- a/hooks/032-move-ssh-config.chroot
+++ b/hooks/032-move-ssh-config.chroot
@@ -20,3 +20,8 @@ ln -s ../ssh.socket "$distro_sysd_d"/ssh.service.requires/ssh.socket
 admin_sysd_d=/etc/systemd/system
 rm "$admin_sysd_d"/sockets.target.wants/ssh.socket
 rm -r "$admin_sysd_d"/ssh.service.requires
+
+# For the ssh.socket to be considered enabled but using symlinks in /usr/lib,
+# the unit needs to be considered "static". To achieve this, the unit [Install]
+# section needs to be removed.
+sed -i -n '/\[Install\]/q;p' /usr/lib/systemd/system/ssh.socket

--- a/tools/generate-changelog.py
+++ b/tools/generate-changelog.py
@@ -69,7 +69,7 @@ def get_changelog_from_file(docs_d, pkg):
         with gzip.open(chl_deb_path) as chl_fh:
             return chl_fh.read().decode('utf-8')
     elif os.path.exists(chl_path):
-        with gzip.open(chl_deb_path) as chl_fh:
+        with gzip.open(chl_path) as chl_fh:
             return chl_fh.read().decode('utf-8')
     else:
         raise FileNotFoundError("no supported changelog found for package " + pkg)


### PR DESCRIPTION
The recent change moving the symlinks enabling ssh.socket to /usr/lib made that
the unit was considered disabled as it was not considered static, although it
was still activated. This was an issue for snapd, that check is the unit is
enabled when changing ssh options. Fix by removing the [Install] section from
the unit.

Backport of https://github.com/canonical/core-base/pull/336