### PR TITLE
many: add tee-supplicant on arm64/armhf systems

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -244,6 +244,12 @@ case "$(dpkg --print-architecture)" in
         ;;
 esac
 
+case "$(dpkg --print-architecture)" in
+    arm64|armhf)
+        PACKAGES+=(tee-supplicant)
+        ;;
+esac
+
 if [[ ${SNAP_FIPS_BUILD+x} ]]; then
     # Ensure vital crypt packages are refreshed / downgraded and downloaded
     # from the FIPS ppa. This should also contain openssh-server, but we already

--- a/hooks/020-extra-files.chroot
+++ b/hooks/020-extra-files.chroot
@@ -40,6 +40,13 @@ mkdir -p /var/lib/waagent
 echo "console-conf directories"
 mkdir -p /var/lib/console-conf
 
+case "$(dpkg --print-architecture)" in
+    arm64|armhf)
+        echo "op-tee secure storage dir"
+	mkdir -p /var/lib/optee-client/data/tee
+        ;;
+esac
+
 echo "ensure snapctl is available"
 ln -s ../lib/snapd/snapctl /usr/bin/snapctl
 

--- a/static/usr/lib/core/remount-core-fs
+++ b/static/usr/lib/core/remount-core-fs
@@ -10,6 +10,7 @@ FILESYSTEMS=(
     /run/mnt/ubuntu-save
     /run/mnt/ubuntu-seed
     /writable
+    /run/mnt/tee-data
 )
 
 for fs in "${FILESYSTEMS[@]}"; do

--- a/static/usr/lib/systemd/system/core.start-snapd.service
+++ b/static/usr/lib/systemd/system/core.start-snapd.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Start the snapd services from the snapd snap
 RequiresMountsFor=/run
-Wants=secureboot-db.service
-After=secureboot-db.service
+Wants=secureboot-db.service tee-supplicant.service
+After=secureboot-db.service tee-supplicant.service
 
 [Service]
 ExecStart=/usr/lib/core/run-snapd-from-snap start

--- a/static/usr/lib/systemd/system/tee-supplicant.service.d/core-override.conf
+++ b/static/usr/lib/systemd/system/tee-supplicant.service.d/core-override.conf
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Adapted from https://github.com/OP-TEE/optee_client/blob/6486773583b5983af8250a47cf07eca938e0e422/tee-supplicant/tee-supplicant%40.service.in
+[Unit]
+DefaultDependencies=no
+BindsTo=dev-teepriv0.device var-lib-optee\x2dclient-data-tee.mount
+After=dev-teepriv0.device var-lib-optee\x2dclient-data-tee.mount
+
+[Service]
+Type=notify
+ExecStartPre=-/usr/sbin/modprobe -v -r tpm_ftpm_tee
+ExecStartPost=-/usr/sbin/modprobe -v tpm_ftpm_tee
+ExecStop=-/bin/sh -c "/sbin/modprobe -v -r tpm_ftpm_tee ; /bin/kill $MAINPID"

--- a/static/usr/lib/systemd/system/tee-supplicant.service.requires/var-lib-optee\x2dclient-data-tee.mount
+++ b/static/usr/lib/systemd/system/tee-supplicant.service.requires/var-lib-optee\x2dclient-data-tee.mount
@@ -1,0 +1,1 @@
+../var-lib-optee\x2dclient-data-tee.mount

--- a/static/usr/lib/systemd/system/var-lib-optee\x2dclient-data-tee.mount
+++ b/static/usr/lib/systemd/system/var-lib-optee\x2dclient-data-tee.mount
@@ -1,0 +1,9 @@
+[Unit]
+ConditionPathIsMountPoint=/run/mnt/tee-data
+DefaultDependencies=no
+
+[Mount]
+What=/run/mnt/tee-data
+Where=/var/lib/optee-client/data/tee
+Options=bind
+Type=none

--- a/static/usr/lib/udev/rules.d/99-optee.rules
+++ b/static/usr/lib/udev/rules.d/99-optee.rules
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Adapted from https://github.com/OP-TEE/optee_client/blob/6486773583b5983af8250a47cf07eca938e0e422/tee-supplicant/optee-udev.rules.in
+KERNEL=="tee[0-9]*", MODE="0660", OWNER="root", GROUP="root", TAG+="systemd"
+KERNEL=="teepriv[0-9]*", MODE="0660", OWNER="root", GROUP="root", TAG+="systemd"
+


### PR DESCRIPTION
This includes tee-supplicant as a service on arm64/armhf systems. tee-supplicant is primarily responsible for providing [Secure Storage](https://optee.readthedocs.io/en/latest/architecture/secure_storage.html) to OP-TEE Trusted Applications, and in the context of Ubuntu Core, specifically the https://github.com/OP-TEE/optee_ftpm TA.

It needs to be implemented as a service in the Core snap instead of as a snap app because, in the fTPM case, it needs to be available when snapd seals the encrypted partitions in install mode and our testing has shown that gadget services do not run early enough to guarantee availability. We also played with the concept of [systemd's Root Storage Daemons](https://systemd.io/ROOT_STORAGE_DAEMONS/) but unfortunately while we can cause the service to survive the initial switchroot killing spree, the second instance of systemd kills it on deserialization as the unit file is no longer there.

This PR adds about 24KB to the compressed size of the arm64 core snap (potentially less with the chiseling done in https://github.com/canonical/core-base/pull/225, I also have slice yaml files available for these packages!). It will not affect architectures other than arm64/armhf.

It is architected so as to not change the running behavior of systems that do not explicitly enable it by passing a data directory from the initrd mounted at /run/mnt/tee-data (see https://github.com/canonical/snapd/pull/15296 for corresponding changes to the core-initrd tooling). 