### PR TITLE
.github,tests: do not rebuild base for each test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,17 +30,17 @@ jobs:
       - name: x86 build
         run: |
           spread -artifacts=./artifacts google-nested:tests/spread/build/
-          find ./artifacts -type f -name "*.artifact" -exec cp {} "${{ github.workspace }}" \;
+          find ./artifacts -type f -name core24_amd64.artifact -exec cp {} "${{ github.workspace }}" \;
       
       - name: arm64 build
         run: |
           spread-arm -artifacts=./artifacts google-nested-arm:tests/spread/build/
-          find ./artifacts -type f -name "*.artifact" -exec cp {} "${{ github.workspace }}" \;
+          find ./artifacts -type f -name core24_arm64.artifact -exec cp {} "${{ github.workspace }}" \;
 
       - uses: actions/upload-artifact@v4
         with:
           name: core-snap
-          path: "${{ github.workspace }}/core24.artifact"
+          path: "${{ github.workspace }}/*.artifact"
 
       - name: Discard spread workers
         if: always()
@@ -63,7 +63,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: core-snap
-          path: "${{ github.workspace }}/core24.artifact"
 
       - name: Run x86 tests
         uses: ./.github/actions/run-spread-tests
@@ -125,7 +124,7 @@ jobs:
 
           echo "************* BUILDING CORE24 IMAGE *************"
           uc_snap="$(get_core_snap_name)"
-          mv core24.artifact "$uc_snap"
+          mv core24_"$(get_arch)".artifact "$uc_snap"
           build_base_image
 
           echo "************* STARTING CORE24 VM *************"

--- a/tests/lib/prepare-uc.sh
+++ b/tests/lib/prepare-uc.sh
@@ -117,11 +117,12 @@ rm -r $snapddir
 
 # build the core24 snap if it has not been provided to us by CI
 uc_snap="$(get_core_snap_name)"
-if [ ! -f "$PROJECT_PATH/core${UC_VERSION}.artifact" ]; then
+artifact="$PROJECT_PATH/core${UC_VERSION}_$(get_arch).artifact"
+if [ ! -f "$artifact" ]; then
     build_base_snap "$PROJECT_PATH"
 else
-    # use provided core24 snap
-    cp "$PROJECT_PATH/core${UC_VERSION}.artifact" "$uc_snap"
+    # use provided base snap
+    cp "$artifact" "$uc_snap"
 fi
 
 # finally build the uc image

--- a/tests/spread/build/build-snap/task.yaml
+++ b/tests/spread/build/build-snap/task.yaml
@@ -2,7 +2,8 @@ summary: Builds the core snap
 manual: true
 
 artifacts:
-  - core24.artifact
+  - core24_amd64.artifact
+  - core24_arm64.artifact
 
 prepare: |
   # for various utilities
@@ -18,4 +19,4 @@ execute: |
   build_base_snap "$PROJECT_PATH"
   
   SNAP_NAME="$(get_core_snap_name)"
-  cp "$PROJECT_PATH/$SNAP_NAME" "core24.artifact"
+  cp "$PROJECT_PATH/$SNAP_NAME" core24_"$(get_arch)".artifact


### PR DESCRIPTION
There were some errors on how artifacts were handled which triggered calls to build_base_snap (see prepare-uc.sh) for each test. Make sure this does not happen and that we reuse the uploaded base artifact.