### PR TITLE
.github/workflows/release.yaml: trigger also core22 builds

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: store
     steps:
-      - name: Build and release core24 to beta channel
+      - name: Build and release base to edge channel
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,18 +1,29 @@
-name: Release snap
+name: Release bases
 
 on:
   schedule:
     - cron: "0 3 * * *"
 
 jobs:
-  build_release:
+  build_release_24:
     runs-on: ubuntu-latest
     environment: store
     steps:
-      - name: Build and release core24 to beta channel
+      - name: Build and release core24 to edge channel
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         uses: snapcore/system-snaps-cicd-tools/action-rebuild-base@main
         with:
           branch: core24
+  build_release_22:
+    runs-on: ubuntu-latest
+    environment: store
+    steps:
+      - name: Build and release core22 to edge channel
+        env:
+          LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        uses: snapcore/system-snaps-cicd-tools/action-rebuild-base@main
+        with:
+          branch: core22

--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -217,6 +217,7 @@ sgx:x:119:
 _ssh:x:118:
 polkitd:x:120:
 systemd-coredump:x:999:
+clock:x:998:
 EOF
 cp /etc/group /etc/group.orig # We make a copy for a later sanity-compare
 


### PR DESCRIPTION
Schedule daily builds for core22 too (this was happening only for core24). Note
that builds happen only if there are changes in the repository or if there
changes in the used debian packages.

Additionally, add new user added from udev package recently.
