### PR TITLE
.github/workflows: add release-manual action

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -1,0 +1,15 @@
+name: Release manually snap
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_release:
+    runs-on: ubuntu-latest
+    environment: store
+    steps:
+      - name: Build and release to edge channel
+        env:
+          LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        uses: snapcore/system-snaps-cicd-tools/action-rebuild-base@main

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: [self-hosted, spread-enabled]
     steps:
       - name: Cleanup job workspace
         id: cleanup-job-workspace
@@ -46,7 +46,7 @@ jobs:
           done
 
   tests-main:
-    runs-on: self-hosted
+    runs-on: [self-hosted, spread-enabled]
     needs: build
     steps:
       - name: Cleanup job workspace


### PR DESCRIPTION
Add action to be able to release manually core22 snaps, in case it is deemed necessary.