### PR TITLE
get-version.sh: filter by _$branch suffix when looking at tags

### DIFF
--- a/get-version.sh
+++ b/get-version.sh
@@ -1,7 +1,12 @@
-#!/bin/bash -ex
+#!/bin/bash -exu
 
-tag=$(git tag --points-at HEAD | grep -E '^[0-9]{8}(-[0-9]+)?$' |
-          sort --field-separator=- --key=1n,1 --key=2n,2 | tail -n1 || printf "")
+# Limit what branch can be to avoid weird regex in the call to sed
+branch=$(git rev-parse --abbrev-ref HEAD | grep -E '^[a-z0-9/-]+$' || printf "")
+tag=
+if [ -n "$branch" ]; then
+    tag=$(git tag --points-at HEAD | sed -nE "s#^([0-9]{8}(-[0-9]+)?)_$branch\$#\\1#p" |
+              sort --field-separator=- --key=1n,1 --key=2n,2 | tail -n1 || printf "")
+fi
 if [ -z "$tag" ]; then
     # Current date is the default if there are no date tags
     tag=$(/bin/date +%Y%m%d)


### PR DESCRIPTION
We have a branch per base in the core-base repository, so we need to differentiate between date tags to avoid repetition. For this, we will add a _$branch suffix to tags.

Here we take that into account when filtering tags in the get-version.sh script.