### PR TITLE
hooks/001-extra-packages.chroot: add back libtirpc3t64

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -203,6 +203,7 @@ PACKAGES=(
     libpam-modules
     libpam-systemd
     libpam-pwquality
+    libtirpc3t64
     netcat-openbsd
     netplan.io
     opensc


### PR DESCRIPTION
/usr/bin/ss (iproute2) has removed the dependency on libtirpc3t64. Add it back manually to avoid breaking ABI.