### PR TITLE
static: copy udev disk rules from core-initrd

### DIFF
--- a/static/usr/lib/udev/rules.d/90-ubuntu-core-partitions.rules
+++ b/static/usr/lib/udev/rules.d/90-ubuntu-core-partitions.rules
@@ -1,0 +1,20 @@
+# This file should be the same as in snapd/core-initrd
+
+SUBSYSTEM!="block", GOTO="ubuntu_core_partitions_end"
+
+ENV{DEVTYPE}=="disk", IMPORT{program}="/usr/lib/snapd/snap-bootstrap scan-disk"
+ENV{DEVTYPE}=="partition", IMPORT{parent}="UBUNTU_DISK"
+ENV{UBUNTU_DISK}!="1", GOTO="ubuntu_core_partitions_end"
+
+ENV{DEVTYPE}=="disk", SYMLINK+="disk/snapd/disk"
+ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-seed", SYMLINK+="disk/snapd/ubuntu-seed"
+ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-boot", SYMLINK+="disk/snapd/ubuntu-boot"
+ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-data", ENV{ID_FS_TYPE}=="crypto_LUKS", SYMLINK+="disk/snapd/ubuntu-data-luks"
+ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-data", ENV{ID_FS_TYPE}!="crypto_LUKS", SYMLINK+="disk/snapd/ubuntu-data"
+ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-save", ENV{ID_FS_TYPE}=="crypto_LUKS", SYMLINK+="disk/snapd/ubuntu-save-luks"
+ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-save", ENV{ID_FS_TYPE}!="crypto_LUKS", SYMLINK+="disk/snapd/ubuntu-save"
+
+LABEL="ubuntu_core_partitions_end"
+
+ENV{DM_UUID}=="CRYPT-*", ENV{DM_NAME}=="ubuntu-data-*", SYMLINK+="disk/snapd/ubuntu-data"
+ENV{DM_UUID}=="CRYPT-*", ENV{DM_NAME}=="ubuntu-save-*", SYMLINK+="disk/snapd/ubuntu-save"


### PR DESCRIPTION
Without matching rules in core-base, the device symlinks created in initrd creates device units which core-base's systemd does not what to do with, and are shown as "activating".