### PR TITLE
Add support for nss-snapd

### DIFF
--- a/hook-tests/002-setup_user.test
+++ b/hook-tests/002-setup_user.test
@@ -5,3 +5,7 @@ set -e
 for prefix in passwd group shadow; do
     grep -q "^${prefix}:.*extrausers" etc/nsswitch.conf
 done
+
+for prefix in passwd group; do
+    grep -q "^${prefix}:.*snapd" etc/nsswitch.conf
+done

--- a/hooks/002-setup_user.chroot
+++ b/hooks/002-setup_user.chroot
@@ -24,8 +24,8 @@ for name in gshadow shadow; do
 done
 
 # Enable libnss-extrusers
-sed -i 's/^passwd:.*files/\0 extrausers/' /etc/nsswitch.conf
-sed -i 's/^group:.*files/\0 extrausers/' /etc/nsswitch.conf
+sed -i 's/^passwd:.*files/\0 extrausers snapd/' /etc/nsswitch.conf
+sed -i 's/^group:.*files/\0 extrausers snapd/' /etc/nsswitch.conf
 sed -i 's/^shadow:.*files/\0 extrausers/' /etc/nsswitch.conf
 
 # Enable pam configuration for extrausers

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -48,6 +48,13 @@ parts:
       copyright: usr/share/doc/plymouth-theme-ubuntu-core/copyright
     stage:
       - -README.md
+  nss-snapd:
+    plugin: make
+    source: https://github.com/canonical/nss-snapd.git
+    source-type: git
+    make-parameters:
+      - prefix=/usr
+      - libdir=/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}
   bootstrap:
     after:
       - base


### PR DESCRIPTION
This adds the nss-snapd NSS plugin that allows resolving the user and group of the user that is using a snap application using core24 base even if there is no entry in /etc/passwd for the calling user. This is useful on corporate laptops.