### PR TITLE
static/usr/lib/udev/rules.d: replace partition scanning with symlink …

### DIFF
--- a/hooks/699-cleanup-misc.chroot
+++ b/hooks/699-cleanup-misc.chroot
@@ -106,3 +106,11 @@ for f in *; do
 done
 rm "${compl_to_rm[@]}"
 popd
+
+# Remove some tmpfiles entries that fail as they try to write in a read-only dir
+sed -i '/\/etc\/default\/locale/d' /usr/lib/tmpfiles.d/debian.conf
+sed -i '/\/etc\/vconsole.conf/d' /usr/lib/tmpfiles.d/debian.conf
+
+# /run/lock is already created by debian.conf, remove duplication
+# TODO this is deb package problem, report upstream
+sed -i '/d \/run\/lock 0755/d' /usr/lib/tmpfiles.d/legacy.conf

--- a/static/usr/lib/udev/rules.d/90-ubuntu-core-partitions.rules
+++ b/static/usr/lib/udev/rules.d/90-ubuntu-core-partitions.rules
@@ -1,21 +1,21 @@
-# This file should be the same as in snapd/core-initrd
-
+# This file ensures that we keep the device units created by the file with the
+# same name in snapd/core-initrd.
 SUBSYSTEM!="block", GOTO="ubuntu_core_partitions_end"
 KERNEL=="loop*|mmcblk[0-9]boot[0-9]", GOTO="ubuntu_core_partitions_end"
 
-ENV{DEVTYPE}=="disk", IMPORT{program}="/usr/lib/snapd/snap-bootstrap scan-disk"
-ENV{DEVTYPE}=="partition", IMPORT{parent}="UBUNTU_DISK"
-ENV{UBUNTU_DISK}!="1", GOTO="ubuntu_core_partitions_end"
-
-ENV{DEVTYPE}=="disk", SYMLINK+="disk/snapd/disk"
-ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-seed", SYMLINK+="disk/snapd/ubuntu-seed"
-ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-boot", SYMLINK+="disk/snapd/ubuntu-boot"
-ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-data", ENV{ID_FS_TYPE}=="crypto_LUKS", SYMLINK+="disk/snapd/ubuntu-data-luks"
-ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-data", ENV{ID_FS_TYPE}!="crypto_LUKS", SYMLINK+="disk/snapd/ubuntu-data"
-ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-save", ENV{ID_FS_TYPE}=="crypto_LUKS", SYMLINK+="disk/snapd/ubuntu-save-luks"
-ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-save", ENV{ID_FS_TYPE}!="crypto_LUKS", SYMLINK+="disk/snapd/ubuntu-save"
+PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/disk ] && [ $$(readlink -f /dev/disk/snapd/disk) = /dev/%k ]'", \
+    SYMLINK+="disk/snapd/disk"
+PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/ubuntu-seed ] && [ $$(readlink -f /dev/disk/snapd/ubuntu-seed) = /dev/%k ]'", \
+    SYMLINK+="disk/snapd/ubuntu-seed"
+PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/ubuntu-boot ] && [ $$(readlink -f /dev/disk/snapd/ubuntu-boot) = /dev/%k ]'", \
+    SYMLINK+="disk/snapd/ubuntu-boot"
+PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/ubuntu-data-luks ] && [ $$(readlink -f /dev/disk/snapd/ubuntu-data-luks) = /dev/%k ]'", \
+    SYMLINK+="disk/snapd/ubuntu-data-luks"
+PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/ubuntu-data ] && [ $$(readlink -f /dev/disk/snapd/ubuntu-data) = /dev/%k ]'", \
+    SYMLINK+="disk/snapd/ubuntu-data"
+PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/ubuntu-save-luks ] && [ $$(readlink -f /dev/disk/snapd/ubuntu-save-luks) = /dev/%k ]'", \
+    SYMLINK+="disk/snapd/ubuntu-save-luks"
+PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/ubuntu-save ] && [ $$(readlink -f /dev/disk/snapd/ubuntu-save) = /dev/%k ]'", \
+    SYMLINK+="disk/snapd/ubuntu-save"
 
 LABEL="ubuntu_core_partitions_end"
-
-ENV{DM_UUID}=="CRYPT-*", ENV{DM_NAME}=="ubuntu-data-*", SYMLINK+="disk/snapd/ubuntu-data"
-ENV{DM_UUID}=="CRYPT-*", ENV{DM_NAME}=="ubuntu-save-*", SYMLINK+="disk/snapd/ubuntu-save"

--- a/static/usr/lib/udev/rules.d/90-ubuntu-core-partitions.rules
+++ b/static/usr/lib/udev/rules.d/90-ubuntu-core-partitions.rules
@@ -1,21 +1,34 @@
-# This file ensures that we keep the device units created by the file with the
-# same name in snapd/core-initrd.
+# This file should be the same as in snapd/core-initrd
+
 SUBSYSTEM!="block", GOTO="ubuntu_core_partitions_end"
 KERNEL=="loop*|mmcblk[0-9]boot[0-9]", GOTO="ubuntu_core_partitions_end"
 
-PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/disk ] && [ $$(readlink -f /dev/disk/snapd/disk) = /dev/%k ]'", \
-    SYMLINK+="disk/snapd/disk"
-PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/ubuntu-seed ] && [ $$(readlink -f /dev/disk/snapd/ubuntu-seed) = /dev/%k ]'", \
-    SYMLINK+="disk/snapd/ubuntu-seed"
-PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/ubuntu-boot ] && [ $$(readlink -f /dev/disk/snapd/ubuntu-boot) = /dev/%k ]'", \
-    SYMLINK+="disk/snapd/ubuntu-boot"
-PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/ubuntu-data-luks ] && [ $$(readlink -f /dev/disk/snapd/ubuntu-data-luks) = /dev/%k ]'", \
-    SYMLINK+="disk/snapd/ubuntu-data-luks"
-PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/ubuntu-data ] && [ $$(readlink -f /dev/disk/snapd/ubuntu-data) = /dev/%k ]'", \
-    SYMLINK+="disk/snapd/ubuntu-data"
-PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/ubuntu-save-luks ] && [ $$(readlink -f /dev/disk/snapd/ubuntu-save-luks) = /dev/%k ]'", \
-    SYMLINK+="disk/snapd/ubuntu-save-luks"
-PROGRAM=="/usr/bin/sh -c '[ -L /dev/disk/snapd/ubuntu-save ] && [ $$(readlink -f /dev/disk/snapd/ubuntu-save) = /dev/%k ]'", \
-    SYMLINK+="disk/snapd/ubuntu-save"
+# Pull from db from a previous event for this device if it exists
+IMPORT{db}="UBUNTU_DISK"
+ENV{DEVTYPE}=="partition", IMPORT{parent}="UBUNTU_DISK"
+
+TEST=="/run/snapd/ubuntu-disk-already-found", GOTO="ubuntu_core_partitions_already_scanned"
+
+ENV{DEVTYPE}=="disk", IMPORT{program}="/usr/lib/snapd/snap-bootstrap scan-disk"
+# TODO move this to be done by "snap-bootstrap scan"
+ENV{UBUNTU_DISK}=="1", RUN+="/usr/bin/mkdir -p /run/snapd/", RUN+="/usr/bin/touch /run/snapd/ubuntu-disk-already-found"
+
+LABEL="ubuntu_core_partitions_already_scanned"
+
+ENV{UBUNTU_DISK}!="1", GOTO="ubuntu_core_partitions_end"
+
+# Ensure UBUNTU_DISK survives "udevadm info --cleanup-db"
+OPTIONS+="db_persist"
+
+ENV{DEVTYPE}=="disk", SYMLINK+="disk/snapd/disk"
+ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-seed", SYMLINK+="disk/snapd/ubuntu-seed"
+ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-boot", SYMLINK+="disk/snapd/ubuntu-boot"
+ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-data", ENV{ID_FS_TYPE}=="crypto_LUKS", SYMLINK+="disk/snapd/ubuntu-data-luks"
+ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-data", ENV{ID_FS_TYPE}!="crypto_LUKS", SYMLINK+="disk/snapd/ubuntu-data"
+ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-save", ENV{ID_FS_TYPE}=="crypto_LUKS", SYMLINK+="disk/snapd/ubuntu-save-luks"
+ENV{DEVTYPE}=="partition", ENV{ID_PART_ENTRY_NAME}=="ubuntu-save", ENV{ID_FS_TYPE}!="crypto_LUKS", SYMLINK+="disk/snapd/ubuntu-save"
 
 LABEL="ubuntu_core_partitions_end"
+
+ENV{DM_UUID}=="CRYPT-*", ENV{DM_NAME}=="ubuntu-data*", SYMLINK+="disk/snapd/ubuntu-data"
+ENV{DM_UUID}=="CRYPT-*", ENV{DM_NAME}=="ubuntu-save*", SYMLINK+="disk/snapd/ubuntu-save"


### PR DESCRIPTION
…validation

Prevent running twice 'snap-boostrap scan', once in initramfs and next time from the rootfs. Instead, recreate the device units by using the symlinks already in /dev/disk. This ensures that the units are the same, is faster, and also prevents the issue that on first boot /usr/lib/snapd/snap-bootstrap is not yet available when the rules are run, as usr-lib-snapd.mount has not been created yet. This provoked error like:

zram0: Failed to find and pin callout binary "/usr/lib/snapd/snap-bootstrap": No such file or directory