### PR TITLE
tools: do not use python3.12 feature since this builds with python3.10

### DIFF
--- a/tools/generate-changelog.py
+++ b/tools/generate-changelog.py
@@ -265,7 +265,7 @@ def main():
     # add a header that helps us audit where the current build is
     # sourced from.
     now = datetime.now()
-    changes = f"{now.strftime("%d/%m/%Y")}, commit {read_remote_git_url()}/tree/{ccommit}\n\n"
+    changes = f'{now.strftime("%d/%m/%Y")}, commit {read_remote_git_url()}/tree/{ccommit}\n\n'
     changes += f'[ Changes in the {args.name} snap ]\n\n'
 
     # Is there a previous commit? Then we get a log between them


### PR DESCRIPTION
Usage of nested quotes of the same type in format strings was introduced in https://peps.python.org/pep-0701. This isn't available until python3.12.

All core22 builds are failing because of this right now: https://code.launchpad.net/~ubuntu-core-service/+snap/core22