### PR TITLE
static/usr/lib/wsl: create empty wsl dir in base

### DIFF
--- a/hooks/020-extra-files.chroot
+++ b/hooks/020-extra-files.chroot
@@ -55,3 +55,6 @@ chmod 0644 /usr/lib/systemd/system.conf.d/11-snapd-ctrl-alt-del-burst.conf
 
 mkdir -p /etc/iproute2
 mkdir -p /var/lib/dhcp
+
+echo "creating wsl mount point"
+mkdir -p /usr/lib/wsl

--- a/static/usr/lib/wsl/README
+++ b/static/usr/lib/wsl/README
@@ -1,0 +1,1 @@
+This directory is a placeholder for mounting runtime libraries from a WSL host.

--- a/static/usr/lib/wsl/README
+++ b/static/usr/lib/wsl/README
@@ -1,1 +1,0 @@
-This directory is a placeholder for mounting runtime libraries from a WSL host.


### PR DESCRIPTION
See comment 1: https://github.com/canonical/snapd/pull/16726#discussion_r2964300217
See comment 2: https://github.com/canonical/snapd/pull/16726#issuecomment-4175511015

This PR adds the `/usr/lib/wsl` directory to the static content of the base. The directory is empty, except for a readme explaining what it is for. The content of `/usr/lib/wsl` from a WSL2 host will be mounted over this directory at runtime.

Please also cherrypick this commit on to core22, core24 and core26.