### PR TITLE
snapcraft, hooks: include /usr/share/X11/XErrorDB

### DIFF
--- a/hooks/602-cleanup-xkb.chroot
+++ b/hooks/602-cleanup-xkb.chroot
@@ -10,4 +10,3 @@ echo "I: Removing xkb data"
 # Remove /usr/share/xkeyboard-config-2 and the symlink to it (/usr/share/X11/xkb)
 rm -rv /usr/share/xkeyboard-config-2
 rm -v /usr/share/X11/xkb
-rmdir /usr/share/X11

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -138,6 +138,7 @@ parts:
         libpam-pwquality_libs
         libpciaccess0_libs
         libwrap0_host-files
+        libx11-data_xerrordb
         locales_standard
 
         netcat-openbsd_bins


### PR DESCRIPTION
Include /usr/share/X11/XErrorDB (~42KB). This avoids needing to ship the
file in the GPU drivers snap (typically mesa-2604) and setting it up in
place with the help of snap layouts, which in turn would require
construction of a writable mimic on top of /usr/share/X11.

Related: https://github.com/canonical/snapcraft/pull/6188