### PR TITLE
snapcraft.yaml: ensure that we install only on RVA23 compliant devices for riscv

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,7 +7,9 @@ confinement: strict
 type: base
 build-base: core26
 grade: stable
-assumes: [snapd2.55.5]
+assumes:
+  - snapd2.55.5
+  - isa-riscv64-rva23
 
 parts:
   # TODO: rewrite this once all slices are upstreamed to use chisel slices


### PR DESCRIPTION
As on resolute we compile all binaries assuming RVA23.