### PR TITLE
snapcraft.yaml: comment out isa-riscv64-rva23

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,8 @@ build-base: core26
 grade: stable
 assumes:
   - snapd2.55.5
-  - isa-riscv64-rva23
+  # This is uncommented in our github builds for riscv64
+  ## - isa-riscv64-rva23
 
 parts:
   # TODO: rewrite this once all slices are upstreamed to use chisel slices


### PR DESCRIPTION
Comment out isa-riscv64-rva23 assumes. Our github build process will uncomment it only for riscv64 architecture. This is needed because snapd versions previous to 2.75 fail to install core26 if the flag is present, for any architecture. And in many cases the snapd present is the one from the debian package.