### PR TITLE
hooks: update nvidia driver version 

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -282,7 +282,7 @@ case "$(dpkg --print-architecture)" in
         # Copy nvidia config files and dependencies (sources for this come from
         # Canonical, not from Nvidia, see
         # https://github.com/canonical/nvidia-graphics-drivers).
-        nvidia_common_pkg=nvidia-kernel-common-570
+        nvidia_common_pkg=nvidia-kernel-common-580
         apt-get download "$nvidia_common_pkg"
         dpkg --fsys-tarfile "$nvidia_common_pkg"_*.deb |
             tar xf - \


### PR DESCRIPTION
[570 is now a transitional package to 580](https://launchpad.net/ubuntu/+source/nvidia-graphics-drivers-570/570.211.01-0ubuntu1.24.04.1)

This change should fix the [core24 build failure](https://launchpadlibrarian.net/859370526/buildlog_snap_ubuntu_noble_amd64_core24_BUILDING.txt.gz):

```
:: + dpkg --fsys-tarfile nvidia-kernel-common-570_570.211.01-0ubuntu1.24.04.1_amd64.deb
:: + tar xf - ./sbin/ub-device-create ./lib/udev/rules.d/71-nvidia.rules ./etc/modprobe.d/nvidia-graphics-drivers-kms.conf
:: tar: ./sbin/ub-device-create: Not found in archive
:: tar: ./lib/udev/rules.d/71-nvidia.rules: Not found in archive
:: tar: ./etc/modprobe.d/nvidia-graphics-drivers-kms.conf: Not found in archive
:: tar: Exiting with failure status due to previous errors
```