### PR TITLE
hooks: cleanup the correct doc folders

### DIFF
--- a/hooks/040-remove-slices.chroot
+++ b/hooks/040-remove-slices.chroot
@@ -12,6 +12,7 @@ rm /usr/bin/file
 
 # remove libmagic1
 rm /usr/lib/*-linux-*/libmagic.so.1*
+rm -rf /usr/share/doc/libmagic1t64
 
 # remove libsemanage-common
 rm /etc/selinux/semanage.conf

--- a/hooks/400-trim-pkcs-11.chroot
+++ b/hooks/400-trim-pkcs-11.chroot
@@ -24,8 +24,8 @@ echo "Cleaning excess pkcs#11 library"
 find /usr/lib -name 'libevent*' -delete
 find /usr/lib -name 'libgnutls-dane*' -delete
 find /usr/lib -name 'libunbound*' -delete
-rm -rf /usr/share/doc/libevent-2.1-7
-rm -rf /usr/share/doc/libgnutls-dane0
+rm -rf /usr/share/doc/libevent-2.1-7t64
+rm -rf /usr/share/doc/libgnutls-dane0t64
 rm -rf /usr/share/doc/libunbound8
 
 rm -rf \


### PR DESCRIPTION
fixes the remaining listed slices in the manifest: https://github.com/canonical/core-base/issues/443

Before fix:

```
[philip@philip-ws squashfs-root]$ find . -name libgnutls*
./usr/lib/x86_64-linux-gnu/libgnutls.so.30
./usr/lib/x86_64-linux-gnu/libgnutls.so.30.41.1
./usr/share/doc/libgnutls-dane0t64
./usr/share/doc/libgnutls30t64
[philip@philip-ws squashfs-root]$ find . -name libevent*
./usr/share/doc/libevent-2.1-7t64
[philip@philip-ws squashfs-root]$ find . -name libmagic*
./usr/share/doc/libmagic1t64
```

After fix:

```
[philip@philip-ws squashfs-root]$ find . -name libgnutls*
./usr/lib/x86_64-linux-gnu/libgnutls.so.30
./usr/lib/x86_64-linux-gnu/libgnutls.so.30.41.1
./usr/share/doc/libgnutls30t64
[philip@philip-ws squashfs-root]$ find . -name libevent*
[philip@philip-ws squashfs-root]$ find . -name libmagic*
[philip@philip-ws squashfs-root]$ 


[philip@philip-ws chisel]$ cat manifest.json | grep libmagic
[philip@philip-ws chisel]$ cat manifest.json | grep libevent
[philip@philip-ws chisel]$ cat manifest.json | grep libgnutls-dane
[philip@philip-ws chisel]$ 
```