### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/lxd-image.yaml
+++ b/.github/workflows/lxd-image.yaml
@@ -1,6 +1,10 @@
 name: Build LXD image
 on: workflow_dispatch
 
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,10 @@ on:
       - main
       - 'core[0-9][0-9]'
 
+
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Small CI hardening: declares an explicit workflow-level `permissions: contents: read` on 2 workflow(s) that currently inherit the default broad read-write GITHUB_TOKEN.

I inspected each file before including it; none publish, push, comment on issues/PRs, or otherwise write via the GitHub API, so the read-only default does not change behavior. Workflows that need to write (stale, release, gh-pages-deploy, publish actions, etc.) are intentionally left out of this PR.

This is the post-CVE-2025-30066 hardening pattern for default token scope.