### PR TITLE
snapcraft: adjust slices after 26-04 update

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
           echo 'matrix=["regular", "cloud-init"]' >> $GITHUB_OUTPUT
 
   build:
-    runs-on: [self-hosted, spread-enabled]
+    runs-on: [self-hosted, x64, linux, spread-enabled]
     needs: setup
     strategy:
       fail-fast: false
@@ -47,13 +47,13 @@ jobs:
       - name: x86 build
         run: |
           export BUILD_VARIANT
-          spread -artifacts=./artifacts google-nested:tests/spread/build/
+          spread -artifacts=./artifacts openstack-ext:tests/spread/build/
           find ./artifacts -type f -name core26_amd64.artifact -exec cp {} "${{ github.workspace }}" \;
       
       - name: arm64 build
         run: |
           export BUILD_VARIANT
-          spread -artifacts=./artifacts google-nested-arm:tests/spread/build/
+          spread -artifacts=./artifacts openstack-arm-ext:tests/spread/build/
           find ./artifacts -type f -name core26_arm64.artifact -exec cp {} "${{ github.workspace }}" \;
 
       - uses: actions/upload-artifact@v4
@@ -71,7 +71,7 @@ jobs:
           done
 
   tests-main:
-    runs-on: [self-hosted, spread-enabled]
+    runs-on: [self-hosted, x64, linux, spread-enabled]
     needs: [setup, build]
     strategy:
       fail-fast: false
@@ -99,13 +99,13 @@ jobs:
         uses: ./.github/actions/run-spread-tests
         with:
           base-variant: ${{ matrix.variant }}
-          spread-command: spread google-nested:tests/spread/main/
+          spread-command: spread openstack-ext:tests/spread/main/
 
       - name: Run arm64 tests
         uses: ./.github/actions/run-spread-tests
         with:
           base-variant: ${{ matrix.variant }}
-          spread-command: spread google-nested-arm:tests/spread/main/
+          spread-command: spread openstack-arm-ext:tests/spread/main/
 
       - name: Discard spread workers
         if: always()
@@ -123,6 +123,7 @@ jobs:
         variant: ${{ fromJSON(needs.setup.outputs.matrix) }}
     env:
       BUILD_VARIANT: ${{ matrix.variant }}
+      SNAPD_USE_PROXY: 'true'
     steps:
       - name: Cleanup job workspace
         id: cleanup-job-workspace

--- a/hooks/026-remove-systemd-svcs.chroot
+++ b/hooks/026-remove-systemd-svcs.chroot
@@ -7,3 +7,6 @@ rm -f /usr/lib/systemd/system/*/systemd-confext*.service
 rm -f /usr/lib/systemd/system/*/systemd-sysext*.service
 rm -f /usr/lib/systemd/system/systemd-confext*.service
 rm -f /usr/lib/systemd/system/systemd-sysext*.service
+
+# remove generators
+rm -f /usr/lib/systemd/system-generators/systemd-gpt-auto-generator

--- a/hooks/601-cleanup-perl.chroot
+++ b/hooks/601-cleanup-perl.chroot
@@ -2,4 +2,3 @@
 
 # remove perl executables
 rm usr/sbin/luksformat
-rm usr/sbin/update-rc.d

--- a/hooks/699-cleanup-misc.chroot
+++ b/hooks/699-cleanup-misc.chroot
@@ -11,8 +11,6 @@ rm /etc/debian_version
 rm -rf /etc/dpkg
 # whatever is left in /run
 rm -rv run/*
-# includes directory
-rm -rv usr/include
 # some unneeded binaries
 sbin=(add-shell
       arpd

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -78,6 +78,7 @@ parts:
         rfkill_bins
         sed_bins
         sudo-rs_bins
+        sysvinit-utils_scripts
         squashfs-tools_bins
         tar_bins
         util-linux_bins
@@ -90,7 +91,7 @@ parts:
       # Define the system libraries and services that we want to include in the base
       # 
       SLICES=(
-        apparmor_extras
+        apparmor_systemd
         base-files_motd
         base-files_release-info
         base-files_root-defaults

--- a/spread.yaml
+++ b/spread.yaml
@@ -10,12 +10,74 @@ environment:
   # TODO: are these vars needed still?
   LANG: "C.UTF-8"
   LANGUAGE: "en"
-  # XXX temporarily switch to edge to get the fix for
-  # https://bugs.launchpad.net/snapcraft/+bug/2051567
-  SNAPCRAFT_CHANNEL: latest/edge
   BUILD_VARIANT: '$(HOST: echo "$BUILD_VARIANT")'
+  SNAPD_WORK_DIR: '$(HOST: echo "${SPREAD_SNAPD_WORK_DIR:-/var/tmp/work-dir}")'
+  HTTP_PROXY: '$(HOST: echo "$SPREAD_HTTP_PROXY")'
+  http_proxy: '$(HOST: echo "$SPREAD_HTTP_PROXY")'
+  HTTPS_PROXY: '$(HOST: echo "$SPREAD_HTTPS_PROXY")'
+  https_proxy: '$(HOST: echo "$SPREAD_HTTPS_PROXY")'
+  NO_PROXY: '$(HOST: echo "${SPREAD_NO_PROXY:-127.0.0.1}")'
+  no_proxy: '$(HOST: echo "${SPREAD_NO_PROXY:-127.0.0.1}")'
 
 backends:
+  openstack-ext:
+    type: openstack
+    key: '$(HOST: echo "$OS_CREDENTIALS_AMD64_PS7")'
+    plan: shared.medium
+    storage: 30G
+    halt-timeout: 2h
+    wait-timeout: 10m
+    groups: [default]
+    proxy: ingress-haproxy.ps7.canonical.com
+    cidr-port-rel: [10.151.96.0/21:5000]
+    volume-auto-delete: true
+    environment: &openstack-env
+      SNAPD_USE_PROXY: 'true'
+      HTTP_PROXY: 'http://egress.ps7.internal:3128'
+      HTTPS_PROXY: 'http://egress.ps7.internal:3128'
+      http_proxy: 'http://egress.ps7.internal:3128'
+      https_proxy: 'http://egress.ps7.internal:3128'
+      no_proxy: '127.0.0.1,127.0.0.53,localhost'
+      NO_PROXY: '127.0.0.1,127.0.0.53,localhost'
+      NTP_SERVER: 'ntp.ps7.internal'
+    systems: &openstack-nested-systems
+      - ubuntu-26.04-64:
+          image: snapd-spread/ubuntu-26.04-64
+          storage: 30G
+          workers: 12
+  openstack-ext-dev:
+    type: openstack
+    key: '$(HOST: echo "$OS_CREDENTIALS_STG_AMD64_PS7")'
+    plan: shared.medium
+    storage: 30G
+    halt-timeout: 2h
+    wait-timeout: 10m
+    groups: [default]
+    proxy: ingress-haproxy.ps7.canonical.com
+    cidr-port-rel: [10.151.54.0/24:4000]
+    volume-auto-delete: true
+    environment: *openstack-env
+    systems: *openstack-nested-systems
+
+  openstack-arm-ext:
+    type: openstack
+    key: '$(HOST: echo "$OS_CREDENTIALS_ARM64_PS7")'
+    plan: shared.large.arm64
+    halt-timeout: 3h
+    wait-timeout: 10m
+    groups: [default]
+    proxy: ingress-haproxy.ps7.canonical.com
+    cidr-port-rel: [10.151.89.0/24:8000]
+    volume-auto-delete: true
+    environment: *openstack-env
+    systems: &openstack-arm-systems
+      - ubuntu-26.04-arm-64:
+          image: snapd-spread/ubuntu-26.04-arm-64
+          workers: 8
+      - ubuntu-core-26-arm-64:
+          image: snapd-spread/ubuntu-26.04-arm-64-uefi
+          workers: 8
+  
   google-nested:
     type: google
     key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'

--- a/spread.yaml
+++ b/spread.yaml
@@ -77,30 +77,6 @@ backends:
       - ubuntu-core-26-arm-64:
           image: snapd-spread/ubuntu-26.04-arm-64-uefi
           workers: 8
-  
-  google-nested:
-    type: google
-    key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-    location: snapd-spread/us-east1-b
-    plan: n2-standard-4
-    halt-timeout: 2h
-    systems:
-      - ubuntu-26.04-64:
-          workers: 4
-          image: ubuntu-2604-64-virt-enabled
-          storage: 20G
-
-  google-nested-arm:
-    type: google
-    key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-    location: snapd-spread/us-central1-a
-    plan: t2a-standard-4
-    halt-timeout: 2h
-    systems:
-      - ubuntu-26.04-arm-64:
-          workers: 4
-          image: ubuntu-2604-arm-64-virt-enabled
-          storage: 25G
 
   qemu-nested:
     type: qemu
@@ -164,6 +140,15 @@ kill-timeout: 60m
 suites:
   tests/spread/build/:
     summary: Build task for the core snap.
+    prepare: |
+      # for various utilities
+      . "$TESTSLIB/prepare-utils.sh"
+
+      # setup system and snapd proxy to allow tools
+      # to talk to the outside, as we run behind a proxy in the openstack environment.
+      setup_system_proxy
+      RESTART_SNAPD=true
+      setup_snapd_proxy "${RESTART_SNAPD}"
   
   tests/spread/ci/:
     summary: CI specific tasks for core-base.

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -84,6 +84,9 @@ start_nested_core_vm_unit(){
     elif [ "${SPREAD_BACKEND}" = "qemu-nested" ]; then
         PARAM_MEM="-m 2048"
         PARAM_SMP="-smp 1"
+    elif [[ "$SPREAD_BACKEND" = openstack* ]]; then
+        PARAM_MEM="-m 4096"
+        PARAM_SMP="-smp 2"
     else
         echo "unknown spread backend ${SPREAD_BACKEND}"
         exit 1

--- a/tests/lib/prepare-uc.sh
+++ b/tests/lib/prepare-uc.sh
@@ -6,6 +6,13 @@ set -x
 # include auxiliary functions from this script
 . "$TESTSLIB/prepare-utils.sh"
 
+# setup system proxy
+setup_system_proxy
+
+# setup snapd proxy
+RESTART_SNAPD=true
+setup_snapd_proxy "${RESTART_SNAPD}"
+
 # install dependencies
 install_base_deps
 

--- a/tests/lib/prepare-uc.sh
+++ b/tests/lib/prepare-uc.sh
@@ -7,9 +7,13 @@ set -x
 . "$TESTSLIB/prepare-utils.sh"
 
 # setup system proxy
+# needed to talk outside the openstack proxy, which
+# is mostly just to allow us to call 'apt' in install_base_deps
 setup_system_proxy
 
 # setup snapd proxy
+# needed for snapd to talk to the internet so we can do
+# 'snap download' and 'snap install'
 RESTART_SNAPD=true
 setup_snapd_proxy "${RESTART_SNAPD}"
 

--- a/tests/lib/prepare-utils.sh
+++ b/tests/lib/prepare-utils.sh
@@ -158,6 +158,43 @@ get_core_snap_name() {
     echo "core26_${date}_$(get_arch).snap"
 }
 
+setup_snapd_proxy() {
+    if [ "${SNAPD_USE_PROXY:-}" != true ]; then
+        return
+    fi
+    restart=$1
+
+    mkdir -p /etc/systemd/system/snapd.service.d
+    cat <<EOF > /etc/systemd/system/snapd.service.d/proxy.conf
+[Service]
+Environment=HTTPS_PROXY=$HTTPS_PROXY HTTP_PROXY=$HTTP_PROXY https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY NO_PROXY=$NO_PROXY no_proxy=$NO_PROXY
+EOF
+
+    # We change the service configuration so reload and restart
+    # the units to get them applied (if requested)
+    systemctl daemon-reload
+    if [ "$restart" = true ]
+    then systemctl restart snapd.service
+    fi
+}
+
+setup_system_proxy() {
+    if [ "${SNAPD_USE_PROXY:-}" != true ]; then
+        return
+    fi
+
+    mkdir -p "$SNAPD_WORK_DIR"
+    cp -f /etc/environment "$SNAPD_WORK_DIR"/environment.bak
+    {
+        echo "HTTPS_PROXY=$HTTPS_PROXY"
+        echo "HTTP_PROXY=$HTTP_PROXY"
+        echo "https_proxy=$HTTPS_PROXY"
+        echo "http_proxy=$HTTP_PROXY"
+        echo "NO_PROXY=$NO_PROXY"
+        echo "no_proxy=$NO_PROXY"
+    } >> /etc/environment
+}
+
 install_base_deps() {
     sudo apt-get update -qq
 

--- a/tests/spread/build/build-snap/task.yaml
+++ b/tests/spread/build/build-snap/task.yaml
@@ -9,6 +9,13 @@ prepare: |
   # for various utilities
   . "$TESTSLIB/prepare-utils.sh"
 
+  # setup system proxy
+  setup_system_proxy
+
+  # setup snapd proxy
+  RESTART_SNAPD=true
+  setup_snapd_proxy "${RESTART_SNAPD}"
+
   # install dependencies
   install_base_deps
 

--- a/tests/spread/build/build-snap/task.yaml
+++ b/tests/spread/build/build-snap/task.yaml
@@ -9,13 +9,6 @@ prepare: |
   # for various utilities
   . "$TESTSLIB/prepare-utils.sh"
 
-  # setup system proxy
-  setup_system_proxy
-
-  # setup snapd proxy
-  RESTART_SNAPD=true
-  setup_snapd_proxy "${RESTART_SNAPD}"
-
   # install dependencies
   install_base_deps
 


### PR DESCRIPTION
Our chisel fork has been rebased to incorporate the latest 26.04 changes. There has been some smaller reorginization of slices and thus some smaller changes have been made to build.

I also ended up switching the tests to openstack with this PR to make sure things were still building and working. The google backend can no longer be used for CI.