### PR TITLE
snapcraft: add variant-versioning for cloud-init and unify handling 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ install:
 
 	set -eux;						\
 	export SNAP_BUILD_VARIANT="";				\
-	. "$$CRAFT_PROJECT_DIR"/build-env;			\
+	. "$$CRAFT_STAGE"/build-env;			\
 	for f in ./hooks/[0-9]*.chroot; do			\
 		base="$$(basename "$${f}")";			\
 		cp -a "$${f}" $(DESTDIR)/install-data/;		\
@@ -56,7 +56,7 @@ install:
 
 	set -eux;						\
 	export SNAP_BUILD_VARIANT="";				\
-	. "$$CRAFT_PROJECT_DIR"/build-env;			\
+	. "$$CRAFT_STAGE"/build-env;			\
 	for f in ./hooks-build/[0-9]*.build; do			\
 		"$$f" $(DESTDIR);				\
 	done

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,17 +13,9 @@ assumes:
   ## - isa-riscv64-rva23
 
 parts:
-  # TODO: rewrite this once all slices are upstreamed to use chisel slices
-  # directly from canonical, instead of our own chisel-releases repo.
-  chisel-libs:
+  build-env:
     plugin: nil
-    build-packages:
-      - golang
-      - file
-    source: https://github.com/canonical/chisel-ubuntu-core.git
-    source-type: git
-    source-branch: '26.04'
-    override-build: |
+    override-pull: |
       # We use a file with env vars in $CRAFT_PROJECT_DIR to decide whether to
       # include cloud-init or not. This file can be manually created for local
       # builds, or created here if we are running from a launchpad recipe with
@@ -50,6 +42,20 @@ parts:
             fi
           fi
       )
+
+  # TODO: rewrite this once all slices are upstreamed to use chisel slices
+  # directly from canonical, instead of our own chisel-releases repo.
+  chisel-libs:
+    plugin: nil
+    after:
+      - build-env
+    build-packages:
+      - golang
+      - file
+    source: https://github.com/canonical/chisel-ubuntu-core.git
+    source-type: git
+    source-branch: '26.04'
+    override-build: |
       go install github.com/canonical/chisel/cmd/chisel@latest
       
       # Define the system utilities that we want to include in the base
@@ -294,6 +300,7 @@ parts:
       - chisel-libs
       - snapd-files
       - splash-theme
+      - build-env
     plugin: make
     source: .
     build-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -33,7 +33,7 @@ parts:
       # (although in one line).
       if ! [ -e "$CRAFT_PROJECT_DIR"/build-env ]; then
         (
-            cd "${CRAFT_PART_INSTALL}"
+            cd "${CRAFT_PART_SRC}"
             touch build-env
             # parse the snap name from the url, and remove the prefix "core26-" and 
             # suffix "/+build" to get the variant name, if any.
@@ -46,24 +46,26 @@ parts:
         )
       else
         # copy to install dir so that we can use it in the build step
-        cp "$CRAFT_PROJECT_DIR"/build-env "${CRAFT_PART_INSTALL}"/build-env
+        cp "$CRAFT_PROJECT_DIR"/build-env "${CRAFT_PART_SRC}"/build-env
       fi
 
       date_tag=$("$CRAFT_PROJECT_DIR"/get-version.sh)
 
       # make sure we load the build-env here, especially if we're using
       # the locally sourced one.
-      . "${CRAFT_PART_INSTALL}"/build-env
+      . "${CRAFT_PART_SRC}"/build-env
       SNAP_BUILD_VARIANT=${SNAP_BUILD_VARIANT:-}
 
       # handle build variants
       if [ -n "$SNAP_BUILD_VARIANT" ]; then
         craftctl set version="${date_tag}+$SNAP_BUILD_VARIANT"
-        echo "SNAP_BUILD_NAME=core26-$SNAP_BUILD_VARIANT" >> "${CRAFT_PART_INSTALL}"/build-env
+        echo "SNAP_BUILD_NAME=core26-$SNAP_BUILD_VARIANT" >> "${CRAFT_PART_SRC}"/build-env
       else
         craftctl set version="${date_tag}"
-        echo "SNAP_BUILD_NAME=core26" > "${CRAFT_PART_INSTALL}"/build-env
+        echo "SNAP_BUILD_NAME=core26" > "${CRAFT_PART_SRC}"/build-env
       fi
+    override-build: |
+      cp "${CRAFT_PART_SRC}"/build-env "${CRAFT_PART_INSTALL}"/build-env
     prime:
       - -build-env
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: core26
-adopt-info: hooks
+adopt-info: build-env
 summary: Runtime environment based on Ubuntu 26.04
 description: |
   The base snap based on the Ubuntu 26.04 release.
@@ -15,6 +15,7 @@ assumes:
 parts:
   build-env:
     plugin: nil
+    source: .
     override-pull: |
       # We use a file with env vars in $CRAFT_PROJECT_DIR to decide whether to
       # include cloud-init or not. This file can be manually created for local
@@ -30,25 +31,48 @@ parts:
       # }
       #
       # (although in one line).
-      (
-          cd "$CRAFT_PROJECT_DIR"
-          touch build-env
-          # parse the snap name from the url, and remove the prefix "core26-" and 
-          # suffix "/+build" to get the variant name, if any.
-          if [ -n "${SNAPCRAFT_IMAGE_INFO+x}" ]; then
-            SNAP_BUILD_VARIANT=$(printf '%s' "$SNAPCRAFT_IMAGE_INFO" | grep -oP '(?<=core26-).*(?=/\+build)')
-            if [ -n "$SNAP_BUILD_VARIANT" ]; then
-                echo "SNAP_BUILD_VARIANT=$SNAP_BUILD_VARIANT" > build-env
+      if ! [ -e "$CRAFT_PROJECT_DIR"/build-env ]; then
+        (
+            cd "${CRAFT_PART_INSTALL}"
+            touch build-env
+            # parse the snap name from the url, and remove the prefix "core26-" and 
+            # suffix "/+build" to get the variant name, if any.
+            if [ -n "${SNAPCRAFT_IMAGE_INFO+x}" ]; then
+              SNAP_BUILD_VARIANT=$(printf '%s' "$SNAPCRAFT_IMAGE_INFO" | grep -oP '(?<=core26-).*(?=/\+build)')
+              if [ -n "$SNAP_BUILD_VARIANT" ]; then
+                  echo "SNAP_BUILD_VARIANT=$SNAP_BUILD_VARIANT" > build-env
+              fi
             fi
-          fi
-      )
+        )
+      else
+        # copy to install dir so that we can use it in the build step
+        cp "$CRAFT_PROJECT_DIR"/build-env "${CRAFT_PART_INSTALL}"/build-env
+      fi
+
+      date_tag=$("$CRAFT_PROJECT_DIR"/get-version.sh)
+
+      # make sure we load the build-env here, especially if we're using
+      # the locally sourced one.
+      . "${CRAFT_PART_INSTALL}"/build-env
+      SNAP_BUILD_VARIANT=${SNAP_BUILD_VARIANT:-}
+
+      # handle build variants
+      if [ -n "$SNAP_BUILD_VARIANT" ]; then
+        craftctl set version="${date_tag}+$SNAP_BUILD_VARIANT"
+        echo "SNAP_BUILD_NAME=core26-$SNAP_BUILD_VARIANT" >> "${CRAFT_PART_INSTALL}"/build-env
+      else
+        craftctl set version="${date_tag}"
+        echo "SNAP_BUILD_NAME=core26" > "${CRAFT_PART_INSTALL}"/build-env
+      fi
+    prime:
+      - -build-env
 
   # TODO: rewrite this once all slices are upstreamed to use chisel slices
   # directly from canonical, instead of our own chisel-releases repo.
   chisel-libs:
-    plugin: nil
     after:
       - build-env
+    plugin: nil
     build-packages:
       - golang
       - file
@@ -198,7 +222,7 @@ parts:
         wpasupplicant_services
       )
 
-      . "$CRAFT_PROJECT_DIR"/build-env
+      . "$CRAFT_STAGE"/build-env
       SNAP_BUILD_VARIANT=${SNAP_BUILD_VARIANT:-}
       if [ "$SNAP_BUILD_VARIANT" = cloud-init ]; then
           SLICES+=(cloud-init_bins)
@@ -306,24 +330,6 @@ parts:
     build-packages:
       - shellcheck
       - distro-info
-    override-pull: |
-      craftctl default
-
-      date_tag=$(./get-version.sh)
-
-      . "$CRAFT_PROJECT_DIR"/build-env
-      SNAP_BUILD_VARIANT=${SNAP_BUILD_VARIANT:-}
-
-      # handle build variants
-      if [ -n "$SNAP_BUILD_VARIANT" ]; then
-        craftctl set version="${date_tag}+$SNAP_BUILD_VARIANT"
-        echo "SNAP_BUILD_VARIANT=$SNAP_BUILD_VARIANT" > build-env
-        echo "SNAP_BUILD_NAME=core26-$SNAP_BUILD_VARIANT" >> build-env
-      else
-        craftctl set version="${date_tag}"
-        echo "SNAP_BUILD_NAME=core26" > build-env
-      fi
-
     override-prime: |
       craftctl default
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -15,6 +15,7 @@ assumes:
 parts:
   build-env:
     plugin: nil
+    # To retrigger the pull step automatically on changes.
     source: .
     override-pull: |
       # We use a file with env vars in $CRAFT_PROJECT_DIR to decide whether to

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -41,8 +41,13 @@ parts:
       (
           cd "$CRAFT_PROJECT_DIR"
           touch build-env
-          if printf "$SNAPCRAFT_IMAGE_INFO" | grep -q -- "-cloud-init/+build"
-          then echo "SNAP_BUILD_VARIANT=cloud-init" > build-env
+          # parse the snap name from the url, and remove the prefix "core26-" and 
+          # suffix "/+build" to get the variant name, if any.
+          if [ -n "${SNAPCRAFT_IMAGE_INFO+x}" ]; then
+            SNAP_BUILD_VARIANT=$(printf '%s' "$SNAPCRAFT_IMAGE_INFO" | grep -oP '(?<=core26-).*(?=/\+build)')
+            if [ -n "$SNAP_BUILD_VARIANT" ]; then
+                echo "SNAP_BUILD_VARIANT=$SNAP_BUILD_VARIANT" > build-env
+            fi
           fi
       )
       go install github.com/canonical/chisel/cmd/chisel@latest
@@ -195,7 +200,7 @@ parts:
 
       # TODO: not sure about FIPS yet, this will have to come later, chisel has builtin
       # support for ESM, meaning it's something we can request chisel to do for us.
-      # if [[ ${SNAP_FIPS_BUILD+x} ]]; then
+      # if [ "$SNAP_BUILD_VARIANT" = fips ]; then
       #   # Ensure vital crypt packages are refreshed / downgraded and downloaded
       #   # from the FIPS ppa. This should also contain openssh-server, but we already
       #   # have that one listed above.
@@ -299,14 +304,17 @@ parts:
 
       date_tag=$(./get-version.sh)
 
-      # detect whether we are doing a fips build on LP
-      if git remote get-url origin | grep "fips"; then
-        craftctl set version="$date_tag"+fips
-        echo "SNAP_BUILD_VARIANT=fips" > build-env
-        echo "SNAP_BUILD_NAME=core26-fips" >> build-env
+      . "$CRAFT_PROJECT_DIR"/build-env
+      SNAP_BUILD_VARIANT=${SNAP_BUILD_VARIANT:-}
+
+      # handle build variants
+      if [ -n "$SNAP_BUILD_VARIANT" ]; then
+        craftctl set version="${date_tag}+$SNAP_BUILD_VARIANT"
+        echo "SNAP_BUILD_VARIANT=$SNAP_BUILD_VARIANT" > build-env
+        echo "SNAP_BUILD_NAME=core26-$SNAP_BUILD_VARIANT" >> build-env
       else
-        craftctl set version=$date_tag
-        rm -f build-env
+        craftctl set version="${date_tag}"
+        echo "SNAP_BUILD_NAME=core26" > build-env
       fi
 
     override-prime: |

--- a/tests/lib/prepare-utils.sh
+++ b/tests/lib/prepare-utils.sh
@@ -155,6 +155,10 @@ get_arch() {
 
 get_core_snap_name() {
     printf -v date '%(%Y%m%d)T' -1
+    if [ "$BUILD_VARIANT" != "" ]; then
+        echo "core26_${date}+${BUILD_VARIANT}_$(get_arch).snap"
+        return
+    fi
     echo "core26_${date}_$(get_arch).snap"
 }
 

--- a/tests/lib/prepare-utils.sh
+++ b/tests/lib/prepare-utils.sh
@@ -155,7 +155,7 @@ get_arch() {
 
 get_core_snap_name() {
     printf -v date '%(%Y%m%d)T' -1
-    if [ "$BUILD_VARIANT" != "" ]; then
+    if [ "$BUILD_VARIANT" != "regular" ]; then
         echo "core26_${date}+${BUILD_VARIANT}_$(get_arch).snap"
         return
     fi


### PR DESCRIPTION
Introduce variant-versioning that covers cloud-init so versioning will look like:
```
20260629
20260629+cloud-init
20260629+fips
```
Based on the recipe naming instead of the git origin. This makes them easier to distinguish in  the store review tools as well, allowing hopefully for store reviews not to get hung up when there is a massive difference in snap contents.

Additionally this moves the step that generates the build-env to the front of the build, ensuring all other snapcraft tasks can use it.