### PR TITLE
github: add cve-scanning

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,6 +60,7 @@ jobs:
         with:
           name: core-snap-${{ matrix.variant }}
           path: "${{ github.workspace }}/*.artifact"
+          if-no-files-found: error
 
       - name: Discard spread workers
         if: always()
@@ -69,6 +70,45 @@ jobs:
           for r in .spread-reuse.*.yaml; do
             spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')"
           done
+
+  cve-scan:
+    runs-on: ubuntu-latest
+    needs: [setup, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJSON(needs.setup.outputs.matrix) }}
+    env:
+      BUILD_VARIANT: ${{ matrix.variant }}
+    steps:
+      - name: Cleanup job workspace
+        id: cleanup-job-workspace
+        run: |
+          rm -rf "${{ github.workspace }}"
+          mkdir "${{ github.workspace }}"
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: core-snap-${{ matrix.variant }}
+
+      - name: Install CVE scanner
+        run: |
+          sudo snap install review-tools
+
+      # Run just for amd64 for now
+      - name: run CVE scanner for amd64
+        run: |
+          # rename the .artifact to a .snap so that the scanner accepts it
+          mv "${{ github.workspace }}/core26_amd64.artifact" "${{ github.workspace }}/core26_amd64.snap"
+          # this produces a table of detected CVEs and their severity
+          review-tools.scan-snap "${{ github.workspace }}/core26_amd64.snap" > "${{ github.workspace }}/cve-scan-amd64.txt"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cve-scan-${{ matrix.variant }}
+          path: "${{ github.workspace }}/cve-scan-amd64.txt"
 
   tests-main:
     runs-on: [self-hosted, x64, linux, spread-enabled]


### PR DESCRIPTION
As a part of the SSDLC lifecycle, we must have cve scanning integrated into our CI. This must be ported across the branches