### PR TITLE
github: integrate cve-scanning as a part of the regular CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,13 +12,16 @@ on:
       - main
       - 'core[0-9][0-9]'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   build:
-    runs-on: [self-hosted, spread-enabled]
+    runs-on: [self-hosted, x64, linux, spread-enabled]
     steps:
       - name: Cleanup job workspace
         id: cleanup-job-workspace
@@ -29,9 +32,9 @@ jobs:
 
       - name: Build snap
         run: |
-          spread -artifacts=./artifacts google-nested:tests/spread/build/
+          spread -artifacts=./artifacts openstack-ext:tests/spread/build/
           find ./artifacts -type f -name "*.artifact" -exec cp {} "${{ github.workspace }}" \;
-      
+
       - uses: actions/upload-artifact@v4
         with:
           name: core-snap
@@ -45,8 +48,40 @@ jobs:
             spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')"
           done
 
+  cve-scan:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Cleanup job workspace
+        id: cleanup-job-workspace
+        run: |
+          rm -rf "${{ github.workspace }}"
+          mkdir "${{ github.workspace }}"
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: core-snap
+
+      - name: Install CVE scanner
+        run: |
+          sudo snap install review-tools
+
+      - name: run CVE scanner
+        run: |
+          # rename the .artifact to a .snap so that the scanner accepts it
+          mv "${{ github.workspace }}/core22.artifact" "${{ github.workspace }}/core22.snap"
+          # this produces a table of detected CVEs and their severity
+          review-tools.scan-snap "${{ github.workspace }}/core22.snap" > "${{ github.workspace }}/cve-scan-amd64.txt"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cve-scan
+          path: "${{ github.workspace }}/cve-scan-amd64.txt"
+
   tests-main:
-    runs-on: [self-hosted, spread-enabled]
+    runs-on: [self-hosted, x64, linux, spread-enabled]
     needs: build
     steps:
       - name: Cleanup job workspace
@@ -63,7 +98,7 @@ jobs:
       - name: Run tests
         uses: ./.github/actions/run-spread-tests
         with:
-          spread-command: spread google-nested:tests/spread/main/
+          spread-command: spread openstack-ext:tests/spread/main/
 
       - name: Discard spread workers
         if: always()
@@ -72,6 +107,7 @@ jobs:
           for r in .spread-reuse.*.yaml; do
             spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')"
           done
+
   tests-snapd:
     runs-on: ubuntu-latest
     needs: build

--- a/spread.yaml
+++ b/spread.yaml
@@ -3,39 +3,79 @@ project: core22
 environment:
   SETUPDIR: /home/core22
   PROJECT_PATH: $SETUPDIR
-  PATH: $PATH:$PROJECT_PATH/tests/bin
+  PATH: $PATH:$PROJECT_PATH/tests/bin:$PROJECT_PATH/tests/lib/external/snapd-testing-tools/tools/
   TESTSLIB: $PROJECT_PATH/tests/lib
   SNAP_BRANCH: "edge" # stable/edge/beta
   UC_VERSION: 22
   # TODO: are these vars needed still?
   LANG: "C.UTF-8"
   LANGUAGE: "en"
+  SNAPD_WORK_DIR: '$(HOST: echo "${SPREAD_SNAPD_WORK_DIR:-/var/tmp/work-dir}")'
+  HTTP_PROXY: '$(HOST: echo "$SPREAD_HTTP_PROXY")'
+  http_proxy: '$(HOST: echo "$SPREAD_HTTP_PROXY")'
+  HTTPS_PROXY: '$(HOST: echo "$SPREAD_HTTPS_PROXY")'
+  https_proxy: '$(HOST: echo "$SPREAD_HTTPS_PROXY")'
+  NO_PROXY: '$(HOST: echo "${SPREAD_NO_PROXY:-127.0.0.1}")'
+  no_proxy: '$(HOST: echo "${SPREAD_NO_PROXY:-127.0.0.1}")'
 
 backends:
-  google-nested:
-    type: google
-    key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-    location: snapd-spread/us-central1-a
-    plan: n2-standard-2
+  openstack-ext:
+    type: openstack
+    key: '$(HOST: echo "$OS_CREDENTIALS_AMD64_PS7")'
+    plan: shared.medium
+    storage: 30G
     halt-timeout: 2h
-    cpu-family: "Intel Cascade Lake"
-    systems:
+    wait-timeout: 10m
+    groups: [default]
+    proxy: ingress-haproxy.ps7.canonical.com
+    cidr-port-rel: [10.151.96.0/21:5000]
+    volume-auto-delete: true
+    environment: &openstack-env
+      SNAPD_USE_PROXY: 'true'
+      HTTP_PROXY: 'http://egress.ps7.internal:3128'
+      HTTPS_PROXY: 'http://egress.ps7.internal:3128'
+      http_proxy: 'http://egress.ps7.internal:3128'
+      https_proxy: 'http://egress.ps7.internal:3128'
+      no_proxy: '127.0.0.1,127.0.0.53,localhost'
+      NO_PROXY: '127.0.0.1,127.0.0.53,localhost'
+      NTP_SERVER: 'ntp.ps7.internal'
+    systems: &openstack-nested-systems
       - ubuntu-22.04-64:
-          image: ubuntu-2204-64-virt-enabled
-          storage: 25G
-          workers: 14
-
-  google-nested-arm:
-    type: google
-    key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-    location: snapd-spread/us-central1-a
-    plan: t2a-standard-2
+          image: snapd-spread/ubuntu-22.04-64
+          storage: 30G
+          workers: 2
+  openstack-ext-dev:
+    type: openstack
+    key: '$(HOST: echo "$OS_CREDENTIALS_STG_AMD64_PS7")'
+    plan: shared.medium
+    storage: 30G
     halt-timeout: 2h
-    systems:
+    wait-timeout: 10m
+    groups: [default]
+    proxy: ingress-haproxy.ps7.canonical.com
+    cidr-port-rel: [10.151.54.0/24:4000]
+    volume-auto-delete: true
+    environment: *openstack-env
+    systems: *openstack-nested-systems
+
+  openstack-arm-ext:
+    type: openstack
+    key: '$(HOST: echo "$OS_CREDENTIALS_ARM64_PS7")'
+    plan: shared.large.arm64
+    halt-timeout: 3h
+    wait-timeout: 10m
+    groups: [default]
+    proxy: ingress-haproxy.ps7.canonical.com
+    cidr-port-rel: [10.151.89.0/24:8000]
+    volume-auto-delete: true
+    environment: *openstack-env
+    systems: &openstack-arm-systems
       - ubuntu-22.04-arm-64:
-          image: ubuntu-2204-arm-64-virt-enabled
-          storage: 25G
-          workers: 8
+          image: snapd-spread/ubuntu-22.04-arm-64
+          workers: 2
+      - ubuntu-core-22-arm-64:
+          image: snapd-spread/ubuntu-22.04-arm-64-uefi
+          workers: 2
 
   qemu-nested:
     type: qemu
@@ -102,6 +142,15 @@ kill-timeout: 50m
 suites:
   tests/spread/build/:
     summary: Build task for the core snap.
+    prepare: |
+      # for various utilities
+      . "$TESTSLIB/prepare-utils.sh"
+
+      # setup system and snapd proxy to allow tools
+      # to talk to the outside, as we run behind a proxy in the openstack environment.
+      setup_system_proxy
+      RESTART_SNAPD=true
+      setup_snapd_proxy "${RESTART_SNAPD}"
   
   tests/spread/ci/:
     summary: CI specific tasks for core-base.

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -87,6 +87,9 @@ start_nested_core_vm_unit(){
     elif [ "${SPREAD_BACKEND}" = "qemu-nested" ]; then
         PARAM_MEM="-m 2048"
         PARAM_SMP="-smp 1"
+    elif [[ "$SPREAD_BACKEND" = openstack* ]]; then
+        PARAM_MEM="-m 4096"
+        PARAM_SMP="-smp 2"
     else
         echo "unknown spread backend ${SPREAD_BACKEND}"
         exit 1

--- a/tests/lib/prepare-uc.sh
+++ b/tests/lib/prepare-uc.sh
@@ -6,6 +6,17 @@ set -x
 # include auxiliary functions from this script
 . "$TESTSLIB/prepare-utils.sh"
 
+# setup system proxy
+# needed to talk outside the openstack proxy, which
+# is mostly just to allow us to call 'apt' in install_base_deps
+setup_system_proxy
+
+# setup snapd proxy
+# needed for snapd to talk to the internet so we can do
+# 'snap download' and 'snap install'
+RESTART_SNAPD=true
+setup_snapd_proxy "${RESTART_SNAPD}"
+
 # install dependencies
 install_core22_deps
 

--- a/tests/lib/prepare-utils.sh
+++ b/tests/lib/prepare-utils.sh
@@ -149,6 +149,43 @@ download_core22_snaps() {
     snap download snapd --channel=${snap_branch} --basename=upstream-snapd
 }
 
+setup_snapd_proxy() {
+    if [ "${SNAPD_USE_PROXY:-}" != true ]; then
+        return
+    fi
+    restart=$1
+
+    mkdir -p /etc/systemd/system/snapd.service.d
+    cat <<EOF > /etc/systemd/system/snapd.service.d/proxy.conf
+[Service]
+Environment=HTTPS_PROXY=$HTTPS_PROXY HTTP_PROXY=$HTTP_PROXY https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY NO_PROXY=$NO_PROXY no_proxy=$NO_PROXY
+EOF
+
+    # We change the service configuration so reload and restart
+    # the units to get them applied (if requested)
+    systemctl daemon-reload
+    if [ "$restart" = true ]
+    then systemctl restart snapd.service
+    fi
+}
+
+setup_system_proxy() {
+    if [ "${SNAPD_USE_PROXY:-}" != true ]; then
+        return
+    fi
+
+    mkdir -p "$SNAPD_WORK_DIR"
+    cp -f /etc/environment "$SNAPD_WORK_DIR"/environment.bak
+    {
+        echo "HTTPS_PROXY=$HTTPS_PROXY"
+        echo "HTTP_PROXY=$HTTP_PROXY"
+        echo "https_proxy=$HTTPS_PROXY"
+        echo "http_proxy=$HTTP_PROXY"
+        echo "NO_PROXY=$NO_PROXY"
+        echo "no_proxy=$NO_PROXY"
+    } >> /etc/environment
+}
+
 # create two new users that used during testing when executing
 # snapd tests, external for the external backend, and 'test'
 # for the snapd test setup


### PR DESCRIPTION
Ported from https://github.com/canonical/core-base/pull/462 for core22

Unfortunately, to make this even run we have to migrate to openstack and fix some pretty fundamental things here as the pipeline was completely broken